### PR TITLE
Add web UI server and catalog manager

### DIFF
--- a/dynaflow/__main__.py
+++ b/dynaflow/__main__.py
@@ -1,0 +1,14 @@
+"""Entry point for ``python -m dynaflow``."""
+
+from __future__ import annotations
+
+from dynaflow.cli import cli
+
+
+def main() -> None:
+    cli()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()
+

--- a/dynaflow/cli.py
+++ b/dynaflow/cli.py
@@ -1,0 +1,66 @@
+"""Command line interface for DynaFlow."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+
+from dynaflow.ui import DynaflowUIServer
+from dynaflow.ui.catalogs import CatalogManager
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="[%(levelname)s] %(name)s: %(message)s")
+
+
+@click.group()
+@click.option("--verbose", is_flag=True, help="Enable verbose logging output")
+def cli(verbose: bool) -> None:
+    """Manage DynaFlow utilities from the command line."""
+
+    _configure_logging(verbose)
+
+
+@cli.command(help="Launch the interactive web UI")
+@click.option("--host", default="127.0.0.1", show_default=True, help="Host interface")
+@click.option("--port", default=8765, show_default=True, help="Port where the server will listen")
+@click.option(
+    "--open-browser/--no-open-browser",
+    default=False,
+    show_default=True,
+    help="Open the default browser automatically",
+)
+@click.option(
+    "--home",
+    type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=Path),
+    default=None,
+    help=(
+        "Directory used to persist UI metadata. "
+        "Defaults to ~/.dynaflow when not provided."
+    ),
+)
+def ui(host: str, port: int, open_browser: bool, home: Path | None) -> None:
+    storage_path = None
+    if home is not None:
+        home.mkdir(parents=True, exist_ok=True)
+        storage_path = home / "catalogs.json"
+
+    manager = CatalogManager(storage_path=storage_path)
+    server = DynaflowUIServer(
+        host=host,
+        port=port,
+        open_browser=open_browser,
+        catalog_manager=manager,
+    )
+
+    try:
+        server.run()
+    except OSError as exc:  # pragma: no cover - depends on environment
+        raise click.ClickException(str(exc)) from exc
+
+
+__all__ = ["cli"]
+

--- a/dynaflow/ui/__init__.py
+++ b/dynaflow/ui/__init__.py
@@ -1,0 +1,22 @@
+"""DynaFlow web UI utilities."""
+
+from __future__ import annotations
+
+from .server import DynaflowUIServer
+
+__all__ = ["DynaflowUIServer", "run_ui"]
+
+
+def run_ui(host: str = "127.0.0.1", port: int = 8765, open_browser: bool = False) -> None:
+    """Start the built-in web UI server.
+
+    Args:
+        host: Interface where the server will listen for connections.
+        port: TCP port used by the HTTP server.
+        open_browser: When ``True`` the default browser is opened automatically
+            pointing to the generated URL.
+    """
+
+    server = DynaflowUIServer(host=host, port=port, open_browser=open_browser)
+    server.run()
+

--- a/dynaflow/ui/catalogs.py
+++ b/dynaflow/ui/catalogs.py
@@ -1,0 +1,515 @@
+"""Utilities to manage external function catalogs for the web UI."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import threading
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+from urllib.parse import quote, urlsplit, urlunsplit
+
+LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_STORAGE = "catalogs.json"
+
+
+@dataclass
+class CatalogRecord:
+    """Metadata persisted for an installed catalog."""
+
+    alias: str
+    module: str
+    pip_url: str | None = None
+    attribute: str = "function_catalog"
+    metadata: dict[str, Any] = field(default_factory=dict)
+    functions: list[dict[str, Any]] = field(default_factory=list)
+    error: str | None = None
+
+    def dump_config(self) -> dict[str, Any]:
+        """Return a serializable representation for persistence."""
+
+        return {
+            "alias": self.alias,
+            "module": self.module,
+            "pip_url": self.pip_url,
+            "attribute": self.attribute,
+            "metadata": self.metadata,
+        }
+
+    def to_response(self) -> dict[str, Any]:
+        """Representation exposed through the HTTP API."""
+
+        payload = asdict(self)
+        # ``functions`` may include callable references, so make them safe for JSON
+        payload["functions"] = [
+            {
+                **entry,
+                "versions": [
+                    {**version, "metadata": _make_json_safe(version.get("metadata"))}
+                    for version in entry.get("versions", [])
+                ],
+            }
+            for entry in self.functions
+        ]
+        payload["metadata"] = _make_json_safe(payload.get("metadata"))
+        return payload
+
+
+def _make_json_safe(value: Any) -> Any:
+    """Attempt to convert objects into a JSON-friendly representation."""
+
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {key: _make_json_safe(item) for key, item in value.items()}
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        return [_make_json_safe(item) for item in value]
+    return repr(value)
+
+
+class CatalogManager:
+    """Manage local and remote function catalogs used by the UI."""
+
+    _EGG_REGEX = re.compile(r"#egg=([^&#]+)")
+
+    def __init__(
+        self,
+        storage_path: str | Path | None = None,
+        *,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._records: dict[str, CatalogRecord] = {}
+        self._env = env or os.environ
+        self._storage_path = Path(storage_path or self._default_storage_path())
+        self._function_registry_cls = self._resolve_function_registry()
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def storage_path(self) -> Path:
+        return self._storage_path
+
+    @property
+    def supports_function_registry(self) -> bool:
+        return self._function_registry_cls is not None
+
+    def list_catalogs(self) -> list[CatalogRecord]:
+        with self._lock:
+            return [record for record in self._records.values()]
+
+    def aggregated_functions(self) -> list[dict[str, Any]]:
+        summary: dict[str, dict[str, Any]] = {}
+        with self._lock:
+            for record in self._records.values():
+                for entry in record.functions:
+                    name = entry.get("name")
+                    if not name:
+                        continue
+                    group = summary.setdefault(name, {"name": name, "versions": []})
+                    for version in entry.get("versions", []):
+                        enriched = dict(version)
+                        enriched.setdefault("catalog", record.alias)
+                        group["versions"].append(enriched)
+        return sorted(summary.values(), key=lambda item: item["name"].lower())
+
+    def to_payload(self) -> dict[str, Any]:
+        catalogs = [record.to_response() for record in self.list_catalogs()]
+        return {
+            "catalogs": catalogs,
+            "functions": self.aggregated_functions(),
+            "supports_registry": self.supports_function_registry,
+        }
+
+    def install_catalog(
+        self,
+        pip_url: str | None,
+        *,
+        alias: str | None = None,
+        module: str | None = None,
+        attribute: str = "function_catalog",
+        auth: Mapping[str, str] | None = None,
+    ) -> CatalogRecord:
+        """Install a catalog and persist its configuration."""
+
+        parsed = self._parse_spec(pip_url) if pip_url else {}
+        module_name = module or parsed.get("module")
+        if not module_name:
+            raise ValueError(
+                "Module name must be provided either explicitly or within the repository URL."
+            )
+
+        alias_name = alias or parsed.get("alias") or module_name
+
+        with self._lock:
+            if alias_name in self._records:
+                raise ValueError(f"Catalog with alias '{alias_name}' is already registered")
+
+            module_loaded = self._safe_import(module_name)
+            if not module_loaded and pip_url:
+                self._pip_install(self._build_install_spec(pip_url, auth))
+                module_loaded = self._safe_import(module_name)
+            if not module_loaded:
+                raise ImportError(f"Module '{module_name}' could not be imported")
+
+            record = CatalogRecord(
+                alias=alias_name,
+                module=module_name,
+                pip_url=pip_url,
+                attribute=attribute,
+                metadata={
+                    "source": pip_url,
+                    "installed_at": self._current_timestamp(),
+                },
+            )
+            self._refresh_record(record)
+            self._records[alias_name] = record
+            self._save()
+            return record
+
+    def refresh(self, alias: str) -> CatalogRecord:
+        with self._lock:
+            record = self._records.get(alias)
+            if not record:
+                raise KeyError(f"Catalog '{alias}' is not registered")
+            self._refresh_record(record)
+            self._save()
+            return record
+
+    def remove(self, alias: str) -> None:
+        with self._lock:
+            if alias not in self._records:
+                raise KeyError(f"Catalog '{alias}' is not registered")
+            del self._records[alias]
+            self._save()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _default_storage_path(self) -> Path:
+        base = self._env.get("DYNAFLOW_UI_HOME")
+        if base:
+            base_path = Path(base)
+        else:
+            base_path = Path.home() / ".dynaflow"
+        base_path.mkdir(parents=True, exist_ok=True)
+        return base_path / _DEFAULT_STORAGE
+
+    def _resolve_function_registry(self):
+        try:
+            from function_registry import FunctionRegistry  # type: ignore
+
+            return FunctionRegistry
+        except Exception:  # pragma: no cover - optional dependency
+            return None
+
+    def _load(self) -> None:
+        if not self._storage_path.exists():
+            return
+        try:
+            with self._storage_path.open("r", encoding="utf-8") as stream:
+                payload = json.load(stream)
+        except json.JSONDecodeError as exc:  # pragma: no cover - extremely rare
+            LOGGER.warning("Invalid catalogs cache found at %s: %s", self._storage_path, exc)
+            return
+
+        entries = payload.get("catalogs", [])
+        if not isinstance(entries, list):
+            return
+
+        for raw in entries:
+            if not isinstance(raw, Mapping):
+                continue
+            alias = raw.get("alias")
+            module = raw.get("module")
+            if not alias or not module:
+                continue
+            record = CatalogRecord(
+                alias=alias,
+                module=module,
+                pip_url=raw.get("pip_url"),
+                attribute=raw.get("attribute", "function_catalog"),
+                metadata=dict(raw.get("metadata", {})),
+            )
+            self._refresh_record(record)
+            self._records[alias] = record
+
+    def _save(self) -> None:
+        payload = {"catalogs": [record.dump_config() for record in self._records.values()]}
+        self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._storage_path.with_suffix(".tmp")
+        with tmp_path.open("w", encoding="utf-8") as stream:
+            json.dump(payload, stream, indent=2, sort_keys=True)
+        tmp_path.replace(self._storage_path)
+
+    def _refresh_record(self, record: CatalogRecord) -> None:
+        try:
+            catalog_obj = self._load_catalog_object(record.module, record.attribute)
+        except Exception as exc:  # pragma: no cover - best effort
+            record.functions = []
+            record.error = str(exc)
+            LOGGER.warning("Unable to load catalog '%s': %s", record.alias, exc)
+            return
+
+        functions, error = self._extract_functions(catalog_obj)
+        record.functions = functions
+        record.error = error
+
+    def _load_catalog_object(self, module_name: str, attribute: str):
+        module = importlib.import_module(module_name)
+        try:
+            return getattr(module, attribute)
+        except AttributeError as exc:  # pragma: no cover - validated at runtime
+            raise AttributeError(
+                f"Attribute '{attribute}' not found in module '{module_name}'"
+            ) from exc
+
+    def _safe_import(self, module_name: str) -> bool:
+        try:
+            importlib.import_module(module_name)
+            return True
+        except ImportError:
+            return False
+
+    def _pip_install(self, spec: str) -> None:
+        LOGGER.info("Installing catalog dependency: %s", spec)
+        cmd = [sys.executable, "-m", "pip", "install", spec]
+        process = subprocess.run(
+            cmd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if process.returncode != 0:
+            message = process.stderr.strip() or process.stdout.strip() or "unknown"
+            raise RuntimeError(f"Failed to install catalog dependency: {message}")
+
+    def _build_install_spec(
+        self, pip_url: str, auth: Mapping[str, str] | None
+    ) -> str:
+        if not auth:
+            return pip_url
+
+        prefix = ""
+        url = pip_url
+        if pip_url.startswith("git+"):
+            prefix = "git+"
+            url = pip_url[len("git+") :]
+
+        parts = urlsplit(url)
+        if not parts.scheme or not parts.netloc:
+            return pip_url
+
+        credential = self._build_credentials(auth)
+        if not credential:
+            return pip_url
+
+        base_netloc = parts.netloc.split("@", 1)[-1]
+        new_netloc = f"{credential}@{base_netloc}"
+        rebuilt = urlunsplit(
+            (parts.scheme, new_netloc, parts.path, parts.query, parts.fragment)
+        )
+        return f"{prefix}{rebuilt}"
+
+    def _build_credentials(self, auth: Mapping[str, str]) -> str:
+        auth_type = (auth.get("type") or "").lower()
+        if auth_type == "basic":
+            username = quote(auth.get("username", ""))
+            password = quote(auth.get("password", ""))
+            if username or password:
+                return f"{username}:{password}"
+            return ""
+        if auth_type == "token":
+            token = quote(auth.get("token", ""))
+            if not token:
+                return ""
+            username = auth.get("username")
+            if username:
+                return f"{quote(username)}:{token}"
+            return token
+
+        username = auth.get("username")
+        password = auth.get("password")
+        token = auth.get("token")
+        if username is not None and password is not None:
+            return f"{quote(username)}:{quote(password)}"
+        if token is not None:
+            return quote(token)
+        return ""
+
+    def _parse_spec(self, spec: str | None) -> dict[str, str]:
+        if not spec:
+            return {}
+
+        info: dict[str, str] = {}
+        egg_match = self._EGG_REGEX.search(spec)
+        if egg_match:
+            info["module"] = egg_match.group(1)
+
+        cleaned = spec
+        if spec.startswith("git+"):
+            cleaned = spec[len("git+") :]
+
+        parts = urlsplit(cleaned)
+        path = parts.path or cleaned
+        if not info.get("module") and "#egg=" in spec:
+            fragment = spec.split("#egg=", 1)[1]
+            info["module"] = fragment.split("#", 1)[0]
+
+        if path:
+            segment = path.rstrip("/").split("/")[-1]
+            segment = segment.split("@", 1)[0]
+            if segment.endswith(".git"):
+                segment = segment[:-4]
+            if segment:
+                info.setdefault("alias", segment)
+                if "module" not in info:
+                    info["module"] = segment.replace("-", "_")
+
+        return info
+
+    def _extract_functions(self, catalog_obj: Any) -> tuple[list[dict[str, Any]], str | None]:
+        try:
+            raw = self._extract_raw_catalog(catalog_obj)
+            functions = self._normalize_functions(raw)
+            error = None
+        except Exception as exc:  # pragma: no cover - best effort
+            functions = []
+            error = str(exc)
+        return functions, error
+
+    def _extract_raw_catalog(self, catalog_obj: Any) -> Any:
+        for attr in ("describe", "export", "to_dict", "summary", "as_dict"):
+            candidate = getattr(catalog_obj, attr, None)
+            if callable(candidate):
+                result = candidate()
+                if result:
+                    return result
+
+        for attr in ("registry", "_registry", "functions", "_functions"):
+            candidate = getattr(catalog_obj, attr, None)
+            if candidate:
+                return candidate
+
+        if hasattr(catalog_obj, "items"):
+            try:
+                return dict(catalog_obj.items())
+            except Exception:  # pragma: no cover - fall back below
+                pass
+
+        if isinstance(catalog_obj, Mapping):
+            return dict(catalog_obj)
+
+        if hasattr(catalog_obj, "__iter__"):
+            return list(catalog_obj)
+
+        return catalog_obj
+
+    def _normalize_functions(self, raw: Any) -> list[dict[str, Any]]:
+        if raw is None:
+            return []
+        if isinstance(raw, list):
+            return [self._normalize_entry(entry) for entry in raw if entry]
+        if isinstance(raw, Mapping):
+            result = []
+            for name, value in raw.items():
+                entry = self._normalize_value(name, value)
+                if entry:
+                    result.append(entry)
+            return result
+        return []
+
+    def _normalize_entry(self, entry: Any) -> dict[str, Any]:
+        if isinstance(entry, Mapping) and "name" in entry:
+            name = str(entry["name"])
+            versions = entry.get("versions") or []
+            normalized_versions = [
+                self._build_version(version.get("version"), version)
+                for version in versions
+                if isinstance(version, Mapping)
+            ]
+            if not normalized_versions and "function" in entry:
+                normalized_versions = [self._build_version(None, entry)]
+            return {"name": name, "versions": normalized_versions}
+        if isinstance(entry, Mapping):
+            return self._normalize_value(entry.get("name", ""), entry)
+        if isinstance(entry, str):
+            return {"name": entry, "versions": [self._build_version(None, {})]}
+        return {"name": repr(entry), "versions": [self._build_version(None, entry)]}
+
+    def _normalize_value(self, name: Any, value: Any) -> dict[str, Any] | None:
+        if not name:
+            return None
+        name_str = str(name)
+        if isinstance(value, Mapping):
+            versions = []
+            if all(isinstance(key, (str, int, float)) for key in value.keys()):
+                for version, meta in value.items():
+                    versions.append(self._build_version(version, meta))
+            else:
+                versions.append(self._build_version(None, value))
+            return {"name": name_str, "versions": versions or [self._build_version(None, value)]}
+        if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+            versions = [self._build_version(None, item) for item in value]
+            return {"name": name_str, "versions": versions}
+        return {"name": name_str, "versions": [self._build_version(None, value)]}
+
+    def _build_version(self, version: Any, meta: Any) -> dict[str, Any]:
+        info: dict[str, Any] = {
+            "version": None if version is None else str(version),
+            "metadata": {},
+        }
+
+        if isinstance(meta, Mapping):
+            description = (
+                meta.get("description")
+                or meta.get("doc")
+                or meta.get("summary")
+                or meta.get("comment")
+            )
+            if description:
+                info["description"] = str(description)
+            if "version" in meta and info["version"] is None:
+                info["version"] = str(meta["version"])
+            function_obj = meta.get("function")
+            if callable(function_obj):
+                info["callable_name"] = getattr(function_obj, "__name__", repr(function_obj))
+                info["callable_module"] = getattr(function_obj, "__module__", "")
+            metadata = {
+                key: value
+                for key, value in meta.items()
+                if key
+                not in {
+                    "function",
+                    "description",
+                    "doc",
+                    "summary",
+                    "comment",
+                    "version",
+                }
+            }
+            if metadata:
+                info["metadata"] = _make_json_safe(metadata)
+        else:
+            info["description"] = repr(meta)
+            info["metadata"] = _make_json_safe(meta)
+
+        return info
+
+    def _current_timestamp(self) -> str:
+        from datetime import datetime
+
+        return datetime.utcnow().isoformat() + "Z"
+

--- a/dynaflow/ui/server.py
+++ b/dynaflow/ui/server.py
@@ -1,0 +1,287 @@
+"""HTTP server responsible for exposing the interactive UI."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import urllib.parse
+import webbrowser
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from dynaflow.ui.catalogs import CatalogManager
+from dynaflow.utils.validator import validate_flow
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DynaflowUIServer:
+    """Expose a lightweight HTTP server that powers the UI."""
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 8765,
+        *,
+        open_browser: bool = False,
+        catalog_manager: CatalogManager | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.open_browser = open_browser
+        self.catalog_manager = catalog_manager or CatalogManager()
+        self.static_dir = Path(__file__).resolve().parent / "static"
+        self._httpd: ThreadingHTTPServer | None = None
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Start the server and block the current thread."""
+
+        handler = self._build_handler()
+        server = ThreadingHTTPServer((self.host, self.port), handler)
+        server.daemon_threads = True
+        self._httpd = server
+
+        url = f"http://{self.host}:{self.port}/"
+        LOGGER.info("Starting DynaFlow UI at %s", url)
+        print(f"DynaFlow UI available at {url}")
+
+        if self.open_browser:
+            threading.Thread(target=self._open_browser, args=(url,), daemon=True).start()
+
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:  # pragma: no cover - manual interruption
+            print("\nShutting down DynaFlow UI...")
+        finally:
+            server.server_close()
+
+    # ------------------------------------------------------------------
+    def _open_browser(self, url: str) -> None:
+        # Give the server a moment to start
+        time.sleep(0.8)
+        try:  # pragma: no cover - depends on environment
+            webbrowser.open(url, new=2)
+        except Exception as exc:
+            LOGGER.warning("Unable to open browser: %s", exc)
+
+    def _build_handler(self):
+        context = self
+        catalog_manager = self.catalog_manager
+        static_dir = self.static_dir
+
+        class RequestHandler(SimpleHTTPRequestHandler):
+            server_version = "DynaflowUI/1.0"
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, directory=str(static_dir), **kwargs)
+
+            # --------------------------------------------------
+            # Routing helpers
+            # --------------------------------------------------
+            def do_OPTIONS(self):  # noqa: N802 (HTTP verb naming)
+                self.send_response(HTTPStatus.NO_CONTENT)
+                self._send_cors_headers()
+                self.end_headers()
+
+            def do_GET(self):  # noqa: N802 (HTTP verb naming)
+                parsed = urllib.parse.urlparse(self.path)
+                if parsed.path.startswith("/api/"):
+                    self._handle_api_get(parsed)
+                    return
+
+                if parsed.path in {"/", ""}:
+                    self.path = "index.html"
+                super().do_GET()
+
+            def do_POST(self):  # noqa: N802 (HTTP verb naming)
+                parsed = urllib.parse.urlparse(self.path)
+                if parsed.path.startswith("/api/"):
+                    self._handle_api_post(parsed)
+                    return
+                self.send_error(HTTPStatus.NOT_FOUND, "Unsupported endpoint")
+
+            def do_DELETE(self):  # noqa: N802 (HTTP verb naming)
+                parsed = urllib.parse.urlparse(self.path)
+                if parsed.path.startswith("/api/catalogs/"):
+                    self._handle_api_delete(parsed)
+                    return
+                self.send_error(HTTPStatus.NOT_FOUND, "Unsupported endpoint")
+
+            # --------------------------------------------------
+            # API handlers
+            # --------------------------------------------------
+            def _handle_api_get(self, parsed: urllib.parse.ParseResult) -> None:
+                path = parsed.path
+                if path == "/api/health":
+                    self._send_json(HTTPStatus.OK, {"status": "ok"})
+                    return
+                if path == "/api/catalogs":
+                    payload = catalog_manager.to_payload()
+                    self._send_json(HTTPStatus.OK, payload)
+                    return
+                self._send_json(
+                    HTTPStatus.NOT_FOUND,
+                    {"error": "Unknown endpoint", "path": path},
+                )
+
+            def _handle_api_post(self, parsed: urllib.parse.ParseResult) -> None:
+                path = parsed.path
+                if path == "/api/catalogs/install":
+                    self._install_catalog()
+                    return
+                if path.endswith("/refresh") and path.startswith("/api/catalogs/"):
+                    alias = self._extract_alias(path, suffix="/refresh")
+                    if not alias:
+                        self._send_json(
+                            HTTPStatus.BAD_REQUEST,
+                            {"error": "Invalid catalog alias"},
+                        )
+                        return
+                    try:
+                        record = catalog_manager.refresh(alias)
+                    except KeyError as exc:
+                        self._send_json(HTTPStatus.NOT_FOUND, {"error": str(exc)})
+                        return
+                    self._send_json(
+                        HTTPStatus.OK,
+                        {
+                            "catalog": record.to_response(),
+                            "functions": catalog_manager.aggregated_functions(),
+                        },
+                    )
+                    return
+                if path == "/api/flow/validate":
+                    self._validate_flow()
+                    return
+                self._send_json(
+                    HTTPStatus.NOT_FOUND,
+                    {"error": "Unknown endpoint", "path": path},
+                )
+
+            def _handle_api_delete(self, parsed: urllib.parse.ParseResult) -> None:
+                alias = self._extract_alias(parsed.path)
+                if not alias:
+                    self._send_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {"error": "Invalid catalog alias"},
+                    )
+                    return
+                try:
+                    catalog_manager.remove(alias)
+                except KeyError as exc:
+                    self._send_json(HTTPStatus.NOT_FOUND, {"error": str(exc)})
+                    return
+                self.send_response(HTTPStatus.NO_CONTENT)
+                self._send_cors_headers()
+                self.end_headers()
+
+            # --------------------------------------------------
+            # Concrete operations
+            # --------------------------------------------------
+            def _install_catalog(self) -> None:
+                payload = self._read_json_body()
+                if payload is None:
+                    return
+
+                try:
+                    record = catalog_manager.install_catalog(
+                        payload.get("pip_url"),
+                        alias=payload.get("alias"),
+                        module=payload.get("module"),
+                        attribute=payload.get("attribute", "function_catalog"),
+                        auth=payload.get("auth"),
+                    )
+                except (ValueError, ImportError) as exc:
+                    self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+                    return
+                except RuntimeError as exc:
+                    self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
+                    return
+
+                self._send_json(
+                    HTTPStatus.CREATED,
+                    {
+                        "catalog": record.to_response(),
+                        "functions": catalog_manager.aggregated_functions(),
+                    },
+                )
+
+            def _validate_flow(self) -> None:
+                payload = self._read_json_body()
+                if payload is None:
+                    return
+
+                flow = payload.get("flow") or payload
+                valid, errors = validate_flow(flow, return_errors=True)
+                response = {
+                    "valid": bool(valid),
+                    "errors": [self._format_validation_error(error) for error in errors],
+                }
+                status = HTTPStatus.OK if valid else HTTPStatus.UNPROCESSABLE_ENTITY
+                self._send_json(status, response)
+
+            # --------------------------------------------------
+            # Helpers
+            # --------------------------------------------------
+            def _read_json_body(self) -> dict[str, Any] | None:
+                length = int(self.headers.get("Content-Length", "0"))
+                raw = self.rfile.read(length) if length else b""
+                try:
+                    body = json.loads(raw.decode("utf-8") or "{}")
+                except json.JSONDecodeError:
+                    self._send_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {"error": "Invalid JSON payload"},
+                    )
+                    return None
+                return body if isinstance(body, dict) else {"flow": body}
+
+            def _send_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(status)
+                self._send_cors_headers()
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _send_cors_headers(self) -> None:
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.send_header(
+                    "Access-Control-Allow-Headers",
+                    "Content-Type, Authorization, X-Requested-With",
+                )
+                self.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+
+            def _extract_alias(self, path: str, suffix: str = "") -> str | None:
+                trimmed = path[len("/api/catalogs/") :]
+                if suffix and trimmed.endswith(suffix):
+                    trimmed = trimmed[: -len(suffix)]
+                trimmed = trimmed.strip("/")
+                if not trimmed:
+                    return None
+                return urllib.parse.unquote(trimmed)
+
+            def _format_validation_error(self, error: Any) -> dict[str, Any]:
+                message = getattr(error, "message", str(error))
+                path = list(getattr(error, "absolute_path", []))
+                validator = getattr(error, "validator", None)
+                return {
+                    "message": message,
+                    "path": path,
+                    "validator": validator,
+                }
+
+            def log_message(self, format: str, *args: Any) -> None:  # noqa: A003 - part of stdlib API
+                LOGGER.debug("%s - %s", self.address_string(), format % args)
+
+        return RequestHandler
+
+
+__all__ = ["DynaflowUIServer"]
+

--- a/dynaflow/ui/server.py
+++ b/dynaflow/ui/server.py
@@ -36,6 +36,26 @@ class DynaflowUIServer:
         self.catalog_manager = catalog_manager or CatalogManager()
         self.static_dir = Path(__file__).resolve().parent / "static"
         self._httpd: ThreadingHTTPServer | None = None
+        self._validate_static_directory()
+
+    def _validate_static_directory(self) -> None:
+        """Validate that the static directory exists and contains required files.
+
+        Raises:
+            RuntimeError: If static directory or critical files are missing.
+        """
+        if not self.static_dir.exists():
+            raise RuntimeError(f"Static directory not found: {self.static_dir}")
+
+        required_files = ["index.html", "app.js", "styles.css"]
+        missing_files = [
+            f for f in required_files if not (self.static_dir / f).exists()
+        ]
+
+        if missing_files:
+            raise RuntimeError(f"Missing static files: {missing_files}")
+
+        LOGGER.info("Static directory validated: %s", self.static_dir)
 
     # ------------------------------------------------------------------
     def run(self) -> None:
@@ -48,10 +68,14 @@ class DynaflowUIServer:
 
         url = f"http://{self.host}:{self.port}/"
         LOGGER.info("Starting DynaFlow UI at %s", url)
+        LOGGER.info("Serving static files from: %s", self.static_dir)
         print(f"DynaFlow UI available at {url}")
+        print(f"Static files directory: {self.static_dir}")
 
         if self.open_browser:
-            threading.Thread(target=self._open_browser, args=(url,), daemon=True).start()
+            threading.Thread(
+                target=self._open_browser, args=(url,), daemon=True
+            ).start()
 
         try:
             server.serve_forever()
@@ -79,6 +103,9 @@ class DynaflowUIServer:
 
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, directory=str(static_dir), **kwargs)
+                LOGGER.debug(
+                    "RequestHandler initialized with static_dir: %s", static_dir
+                )
 
             # --------------------------------------------------
             # Routing helpers
@@ -90,13 +117,30 @@ class DynaflowUIServer:
 
             def do_GET(self):  # noqa: N802 (HTTP verb naming)
                 parsed = urllib.parse.urlparse(self.path)
+                LOGGER.debug("GET request for path: %s", self.path)
+
                 if parsed.path.startswith("/api/"):
                     self._handle_api_get(parsed)
                     return
 
+                # Handle root path
                 if parsed.path in {"/", ""}:
-                    self.path = "index.html"
-                super().do_GET()
+                    LOGGER.debug("Root path requested, redirecting to index.html")
+                    self.path = "/index.html"
+
+                # Log the final path and static directory
+                LOGGER.debug(
+                    "Serving static file: %s from directory: %s", self.path, static_dir
+                )
+
+                # Ensure static files are served with proper error handling
+                try:
+                    super().do_GET()
+                except Exception as exc:
+                    LOGGER.error("Error serving static file %s: %s", self.path, exc)
+                    self.send_error(
+                        HTTPStatus.NOT_FOUND, f"File not found: {self.path}"
+                    )
 
             def do_POST(self):  # noqa: N802 (HTTP verb naming)
                 parsed = urllib.parse.urlparse(self.path)
@@ -200,7 +244,9 @@ class DynaflowUIServer:
                     self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
                     return
                 except RuntimeError as exc:
-                    self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
+                    self._send_json(
+                        HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)}
+                    )
                     return
 
                 self._send_json(
@@ -220,7 +266,9 @@ class DynaflowUIServer:
                 valid, errors = validate_flow(flow, return_errors=True)
                 response = {
                     "valid": bool(valid),
-                    "errors": [self._format_validation_error(error) for error in errors],
+                    "errors": [
+                        self._format_validation_error(error) for error in errors
+                    ],
                 }
                 status = HTTPStatus.OK if valid else HTTPStatus.UNPROCESSABLE_ENTITY
                 self._send_json(status, response)
@@ -256,7 +304,9 @@ class DynaflowUIServer:
                     "Access-Control-Allow-Headers",
                     "Content-Type, Authorization, X-Requested-With",
                 )
-                self.send_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+                self.send_header(
+                    "Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS"
+                )
 
             def _extract_alias(self, path: str, suffix: str = "") -> str | None:
                 trimmed = path[len("/api/catalogs/") :]
@@ -277,11 +327,12 @@ class DynaflowUIServer:
                     "validator": validator,
                 }
 
-            def log_message(self, format: str, *args: Any) -> None:  # noqa: A003 - part of stdlib API
+            def log_message(
+                self, format: str, *args: Any
+            ) -> None:  # noqa: A003 - part of stdlib API
                 LOGGER.debug("%s - %s", self.address_string(), format % args)
 
         return RequestHandler
 
 
 __all__ = ["DynaflowUIServer"]
-

--- a/dynaflow/ui/static/app.js
+++ b/dynaflow/ui/static/app.js
@@ -1,0 +1,2483 @@
+(() => {
+  const {
+    h,
+    Fragment,
+    render,
+    useState,
+    useEffect,
+    useMemo,
+    useReducer,
+    useCallback,
+    useRef
+  } = MiniReact;
+
+  const NODE_TYPES = [
+    { id: "Task", label: "Task", description: "Execute a registered function" },
+    { id: "Pass", label: "Pass", description: "Inject or transform data" },
+    { id: "Choice", label: "Choice", description: "Branch logic based on data" },
+    { id: "Wait", label: "Wait", description: "Pause execution for a period" },
+    { id: "Parallel", label: "Parallel", description: "Run branches concurrently" },
+    { id: "Map", label: "Map", description: "Iterate over a collection" },
+    { id: "Succeed", label: "Succeed", description: "Mark flow as successful" },
+    { id: "Fail", label: "Fail", description: "Terminate execution with error" }
+  ];
+
+  const CHOICE_OPERATORS = [
+    "StringEquals",
+    "StringMatches",
+    "NumericEquals",
+    "NumericGreaterThan",
+    "NumericLessThan",
+    "BooleanEquals",
+    "TimestampEquals",
+    "TimestampLessThan",
+    "TimestampGreaterThan"
+  ];
+
+  const WAIT_MODES = [
+    { id: "seconds", label: "Wait Seconds" },
+    { id: "timestamp", label: "Wait Until Timestamp" },
+    { id: "secondsPath", label: "Seconds Path" },
+    { id: "timestampPath", label: "Timestamp Path" }
+  ];
+
+  const NODE_NAME_PREFIX = {
+    Task: "Task",
+    Pass: "Pass",
+    Choice: "Choice",
+    Wait: "Wait",
+    Map: "Map",
+    Parallel: "Parallel",
+    Succeed: "Success",
+    Fail: "Fail"
+  };
+
+  function createInitialState() {
+    const rootFlow = createFlow("root", "Root Flow", null);
+    return {
+      flows: { root: rootFlow },
+      currentFlowId: "root",
+      selection: null,
+      catalogs: { items: [], aggregated: [], supportsRegistry: false },
+      showInstallModal: false,
+      validation: { status: "idle", errors: [] },
+      toasts: [],
+      revision: 0
+    };
+  }
+
+  function createFlow(id, label, parent) {
+    return {
+      id,
+      label,
+      comment: "",
+      version: "",
+      startNodeId: null,
+      nodes: {},
+      order: [],
+      parent
+    };
+  }
+
+  function cloneValue(value) {
+    if (value == null || typeof value !== "object") {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => cloneValue(item));
+    }
+    const result = {};
+    Object.keys(value).forEach((key) => {
+      result[key] = cloneValue(value[key]);
+    });
+    return result;
+  }
+
+  function cloneNode(node) {
+    return {
+      ...node,
+      position: { ...node.position },
+      transitions: { ...node.transitions },
+      config: cloneValue(node.config),
+      branchFlowIds: node.branchFlowIds ? node.branchFlowIds.slice() : []
+    };
+  }
+
+  function cloneFlow(flow) {
+    const nodes = {};
+    Object.keys(flow.nodes).forEach((id) => {
+      nodes[id] = cloneNode(flow.nodes[id]);
+    });
+    return {
+      ...flow,
+      nodes,
+      order: flow.order.slice()
+    };
+  }
+
+  function createId(prefix = "node") {
+    if (window.crypto && typeof window.crypto.randomUUID === "function") {
+      return window.crypto.randomUUID();
+    }
+    return `${prefix}-${Math.random().toString(16).slice(2)}`;
+  }
+
+  function ensureUniqueName(flow, baseName, excludeId) {
+    let counter = 1;
+    let candidate = baseName;
+    const taken = new Set(
+      flow.order
+        .filter((id) => id !== excludeId)
+        .map((id) => flow.nodes[id].name.toLowerCase())
+    );
+    while (taken.has(candidate.toLowerCase())) {
+      counter += 1;
+      candidate = `${baseName} ${counter}`;
+    }
+    return candidate;
+  }
+
+  function createTaskConfig() {
+    return {
+      functionFields: [
+        { id: createId("fn"), key: "Name", value: "", required: true }
+      ],
+      parameters: [],
+      inputPath: "",
+      outputPath: "",
+      resultPath: "",
+      heartbeatSeconds: "",
+      timeoutSeconds: "",
+      retry: [],
+      catch: []
+    };
+  }
+
+  function createPassConfig() {
+    return {
+      result: "",
+      resultIsJson: false,
+      parameters: [],
+      inputPath: "",
+      outputPath: "",
+      resultPath: ""
+    };
+  }
+
+  function createChoiceConfig() {
+    return {
+      choices: [
+        {
+          id: createId("choice"),
+          variable: "",
+          operator: "StringEquals",
+          value: "",
+          next: null
+        }
+      ],
+      default: null
+    };
+  }
+
+  function createWaitConfig() {
+    return {
+      mode: "seconds",
+      seconds: "",
+      timestamp: "",
+      secondsPath: "",
+      timestampPath: "",
+      inputPath: "",
+      outputPath: "",
+      resultPath: ""
+    };
+  }
+
+  function createMapConfig(name) {
+    return {
+      itemsPath: "$.items",
+      parameters: [],
+      resultPath: "",
+      maxConcurrency: "",
+      iteratorLabel: `${name} Iterator`
+    };
+  }
+
+  function createParallelConfig(name) {
+    return {
+      branchLabelPrefix: `${name} Branch`
+    };
+  }
+
+  function createFailConfig() {
+    return {
+      error: "",
+      cause: ""
+    };
+  }
+
+  function createSucceedConfig() {
+    return {};
+  }
+
+  function createNodeTemplate(type, flow, options) {
+    const id = createId(type.toLowerCase());
+    const baseName = NODE_NAME_PREFIX[type] || type;
+    const name = ensureUniqueName(flow, baseName, null);
+    const position = options && options.position ? options.position : { x: 120, y: 120 };
+    const baseNode = {
+      id,
+      flowId: flow.id,
+      name,
+      type,
+      comment: "",
+      position,
+      transitions: { next: null, end: false, default: null },
+      config: {},
+      branchFlowIds: []
+    };
+
+    const newFlows = [];
+
+    if (type === "Task") {
+      baseNode.config = createTaskConfig();
+    } else if (type === "Pass") {
+      baseNode.config = createPassConfig();
+    } else if (type === "Choice") {
+      baseNode.config = createChoiceConfig();
+    } else if (type === "Wait") {
+      baseNode.config = createWaitConfig();
+    } else if (type === "Map") {
+      baseNode.config = createMapConfig(name);
+      const branchId = `${id}:iterator`;
+      baseNode.branchFlowIds.push(branchId);
+      newFlows.push(
+        createFlow(branchId, `${name} Iterator`, {
+          flowId: flow.id,
+          nodeId: id,
+          type: "Map",
+          label: `${name} Iterator`
+        })
+      );
+    } else if (type === "Parallel") {
+      baseNode.config = createParallelConfig(name);
+      const branchId = `${id}:branch-1`;
+      baseNode.branchFlowIds.push(branchId);
+      newFlows.push(
+        createFlow(branchId, `${name} Branch 1`, {
+          flowId: flow.id,
+          nodeId: id,
+          type: "Parallel",
+          label: `${name} Branch 1`
+        })
+      );
+    } else if (type === "Fail") {
+      baseNode.config = createFailConfig();
+      baseNode.transitions.end = true;
+    } else if (type === "Succeed") {
+      baseNode.config = createSucceedConfig();
+      baseNode.transitions.end = true;
+    }
+
+    return { node: baseNode, flows: newFlows };
+  }
+
+  function produce(state, mutator, options) {
+    const next = {
+      ...state,
+      flows: { ...state.flows },
+      catalogs: { ...state.catalogs },
+      validation: { ...state.validation },
+      toasts: state.toasts.slice()
+    };
+    mutator(next);
+    if (!options || options.increment !== false) {
+      next.revision = (state.revision || 0) + 1;
+    }
+    return next;
+  }
+
+  function reducer(state, action) {
+    switch (action.type) {
+      case "SET_CATALOGS":
+        return {
+          ...state,
+          catalogs: {
+            items: action.payload.items,
+            aggregated: action.payload.aggregated,
+            supportsRegistry: action.payload.supportsRegistry
+          }
+        };
+      case "TOGGLE_INSTALL_MODAL":
+        return { ...state, showInstallModal: action.visible };
+      case "SET_SELECTION":
+        return { ...state, selection: action.selection };
+      case "CLEAR_SELECTION":
+        return { ...state, selection: null };
+      case "NAVIGATE_FLOW":
+        return { ...state, currentFlowId: action.flowId, selection: null };
+      case "ADD_TOAST":
+        return { ...state, toasts: [...state.toasts, action.toast] };
+      case "REMOVE_TOAST":
+        return {
+          ...state,
+          toasts: state.toasts.filter((toast) => toast.id !== action.id)
+        };
+      case "SET_VALIDATION":
+        return {
+          ...state,
+          validation: { status: action.status, errors: action.errors || [] }
+        };
+      case "ADD_NODE": {
+        const flow = state.flows[action.flowId];
+        if (!flow) {
+          return state;
+        }
+        return produce(state, (draft) => {
+          const baseFlow = cloneFlow(flow);
+          const { node, flows: newFlows } = createNodeTemplate(action.nodeType, baseFlow, {
+            position: action.position
+          });
+          baseFlow.nodes[node.id] = node;
+          baseFlow.order.push(node.id);
+          if (!baseFlow.startNodeId) {
+            baseFlow.startNodeId = node.id;
+          }
+          draft.flows[action.flowId] = baseFlow;
+          newFlows.forEach((branchFlow) => {
+            draft.flows[branchFlow.id] = branchFlow;
+          });
+          draft.selection = { flowId: action.flowId, nodeId: node.id };
+        });
+      }
+      case "UPDATE_NODE_POSITION": {
+        const flow = state.flows[action.flowId];
+        if (!flow || !flow.nodes[action.nodeId]) {
+          return state;
+        }
+        const node = flow.nodes[action.nodeId];
+        if (
+          node.position.x === action.position.x &&
+          node.position.y === action.position.y
+        ) {
+          return state;
+        }
+        return produce(state, (draft) => {
+          const updatedFlow = cloneFlow(flow);
+          const updatedNode = cloneNode(updatedFlow.nodes[action.nodeId]);
+          updatedNode.position = { ...action.position };
+          updatedFlow.nodes[action.nodeId] = updatedNode;
+          draft.flows[action.flowId] = updatedFlow;
+        });
+      }
+      case "UPDATE_NODE": {
+        const flow = state.flows[action.flowId];
+        if (!flow || !flow.nodes[action.nodeId]) {
+          return state;
+        }
+        return produce(state, (draft) => {
+          const updatedFlow = cloneFlow(flow);
+          const node = cloneNode(updatedFlow.nodes[action.nodeId]);
+          if (action.changes.name) {
+            node.name = ensureUniqueName(updatedFlow, action.changes.name, node.id);
+          }
+          if (action.changes.comment !== undefined) {
+            node.comment = action.changes.comment;
+          }
+          if (action.changes.transitions) {
+            node.transitions = { ...node.transitions, ...action.changes.transitions };
+          }
+          if (action.changes.config) {
+            node.config = cloneValue(action.changes.config);
+          }
+          updatedFlow.nodes[action.nodeId] = node;
+          draft.flows[action.flowId] = updatedFlow;
+          if (action.changes.start === true) {
+            updatedFlow.startNodeId = node.id;
+          }
+        });
+      }
+      case "UPDATE_NODE_CONFIG": {
+        const flow = state.flows[action.flowId];
+        if (!flow || !flow.nodes[action.nodeId]) {
+          return state;
+        }
+        return produce(state, (draft) => {
+          const updatedFlow = cloneFlow(flow);
+          const node = cloneNode(updatedFlow.nodes[action.nodeId]);
+          const nextConfig = cloneValue(node.config);
+          action.updater(nextConfig);
+          node.config = nextConfig;
+          updatedFlow.nodes[action.nodeId] = node;
+          draft.flows[action.flowId] = updatedFlow;
+        });
+      }
+      case "SET_FLOW_START": {
+        const flow = state.flows[action.flowId];
+        if (!flow || !flow.nodes[action.nodeId]) {
+          return state;
+        }
+        return produce(state, (draft) => {
+          const updatedFlow = cloneFlow(flow);
+          updatedFlow.startNodeId = action.nodeId;
+          draft.flows[action.flowId] = updatedFlow;
+        });
+      }
+      case "REMOVE_NODE": {
+        const flow = state.flows[action.flowId];
+        if (!flow || !flow.nodes[action.nodeId]) {
+          return state;
+        }
+        return produce(state, (draft) => {
+          const updatedFlow = cloneFlow(flow);
+          const node = updatedFlow.nodes[action.nodeId];
+          delete updatedFlow.nodes[action.nodeId];
+          updatedFlow.order = updatedFlow.order.filter((id) => id !== action.nodeId);
+          if (updatedFlow.startNodeId === action.nodeId) {
+            updatedFlow.startNodeId = updatedFlow.order[0] || null;
+          }
+          updatedFlow.order.forEach((id) => {
+            const current = updatedFlow.nodes[id];
+            if (current.transitions.next === action.nodeId) {
+              current.transitions.next = null;
+            }
+            if (current.transitions.default === action.nodeId) {
+              current.transitions.default = null;
+            }
+            if (current.type === "Choice") {
+              current.config.choices = current.config.choices.map((choice) =>
+                choice.next === action.nodeId ? { ...choice, next: null } : choice
+              );
+            }
+          });
+          if (node.branchFlowIds && node.branchFlowIds.length) {
+            node.branchFlowIds.forEach((flowId) => {
+              removeFlowBranch(draft, flowId);
+            });
+          }
+          draft.flows[action.flowId] = updatedFlow;
+          draft.selection = null;
+        });
+      }
+      case "ADD_PARALLEL_BRANCH": {
+        const flow = state.flows[action.flowId];
+        if (!flow) return state;
+        const node = flow.nodes[action.nodeId];
+        if (!node || node.type !== "Parallel") return state;
+        return produce(state, (draft) => {
+          const updatedFlow = cloneFlow(flow);
+          const updatedNode = cloneNode(updatedFlow.nodes[action.nodeId]);
+          const branchIndex = updatedNode.branchFlowIds.length + 1;
+          const branchId = `${updatedNode.id}:branch-${branchIndex}`;
+          updatedNode.branchFlowIds.push(branchId);
+          updatedFlow.nodes[action.nodeId] = updatedNode;
+          draft.flows[action.flowId] = updatedFlow;
+          const labelPrefix = updatedNode.config.branchLabelPrefix || `${updatedNode.name} Branch`;
+          draft.flows[branchId] = createFlow(branchId, `${labelPrefix} ${branchIndex}`, {
+            flowId: flow.id,
+            nodeId: action.nodeId,
+            type: "Parallel",
+            label: `${labelPrefix} ${branchIndex}`
+          });
+        });
+      }
+      case "REMOVE_PARALLEL_BRANCH": {
+        const flow = state.flows[action.flowId];
+        if (!flow) return state;
+        const node = flow.nodes[action.nodeId];
+        if (!node || node.type !== "Parallel") return state;
+        if (node.branchFlowIds.length <= 1) return state;
+        return produce(state, (draft) => {
+          const updatedFlow = cloneFlow(flow);
+          const updatedNode = cloneNode(updatedFlow.nodes[action.nodeId]);
+          const [removed] = updatedNode.branchFlowIds.splice(action.index, 1);
+          updatedFlow.nodes[action.nodeId] = updatedNode;
+          draft.flows[action.flowId] = updatedFlow;
+          if (removed) {
+            removeFlowBranch(draft, removed);
+          }
+        });
+      }
+      case "UPDATE_FLOW": {
+        const flow = state.flows[action.flowId];
+        if (!flow) return state;
+        return produce(state, (draft) => {
+          draft.flows[action.flowId] = { ...flow, ...action.changes };
+        });
+      }
+      default:
+        return state;
+    }
+  }
+
+  function removeFlowBranch(state, flowId) {
+    const branch = state.flows[flowId];
+    if (!branch) {
+      return;
+    }
+    Object.values(branch.nodes).forEach((node) => {
+      if (node.branchFlowIds && node.branchFlowIds.length) {
+        node.branchFlowIds.forEach((nested) => removeFlowBranch(state, nested));
+      }
+    });
+    delete state.flows[flowId];
+  }
+
+  function formatToast(message, tone) {
+    return {
+      id: createId("toast"),
+      message,
+      tone,
+      timestamp: Date.now()
+    };
+  }
+
+  function buildFlowExport(state) {
+    const rootFlow = state.flows["root"];
+    return exportFlow(state, rootFlow);
+  }
+
+  function exportFlow(state, flow) {
+    if (!flow) {
+      return {};
+    }
+    const result = {};
+    if (flow.comment) {
+      result.Comment = flow.comment;
+    }
+    if (flow.version) {
+      result.Version = flow.version;
+    }
+    if (flow.startNodeId && flow.nodes[flow.startNodeId]) {
+      result.StartAt = flow.nodes[flow.startNodeId].name;
+    }
+    const states = {};
+    flow.order.forEach((nodeId) => {
+      const node = flow.nodes[nodeId];
+      states[node.name] = exportNode(state, flow, node);
+    });
+    result.States = states;
+    return result;
+  }
+
+  function exportNode(state, flow, node) {
+    const base = { Type: node.type };
+    if (node.comment) {
+      base.Comment = node.comment;
+    }
+    if (node.transitions.end) {
+      base.End = true;
+    } else if (node.transitions.next && flow.nodes[node.transitions.next]) {
+      base.Next = flow.nodes[node.transitions.next].name;
+    }
+
+    if (node.type === "Task") {
+      Object.assign(base, exportTask(node));
+    } else if (node.type === "Pass") {
+      Object.assign(base, exportPass(node));
+    } else if (node.type === "Choice") {
+      Object.assign(base, exportChoice(flow, node));
+    } else if (node.type === "Wait") {
+      Object.assign(base, exportWait(node));
+    } else if (node.type === "Map") {
+      Object.assign(base, exportMap(state, node));
+    } else if (node.type === "Parallel") {
+      Object.assign(base, exportParallel(state, node));
+    } else if (node.type === "Fail") {
+      Object.assign(base, exportFail(node));
+    } else if (node.type === "Succeed") {
+      Object.assign(base, exportSucceed());
+    }
+    return base;
+  }
+
+  function exportTask(node) {
+    const payload = {};
+    const fn = {};
+    (node.config.functionFields || []).forEach((field) => {
+      if (!field.key) return;
+      if (field.key === "Name" && !field.value) return;
+      fn[field.key] = coerceValue(field.value);
+    });
+    if (Object.keys(fn).length) {
+      payload.Function = fn;
+    }
+    if (node.config.inputPath) payload.InputPath = node.config.inputPath;
+    if (node.config.outputPath) payload.OutputPath = node.config.outputPath;
+    if (node.config.resultPath) payload.ResultPath = node.config.resultPath;
+    if (node.config.heartbeatSeconds) payload.HeartbeatSeconds = Number(node.config.heartbeatSeconds);
+    if (node.config.timeoutSeconds) payload.TimeoutSeconds = Number(node.config.timeoutSeconds);
+    const params = exportParameters(node.config.parameters || []);
+    if (params) payload.Parameters = params;
+    return payload;
+  }
+
+  function exportPass(node) {
+    const payload = {};
+    if (node.config.result) {
+      payload.Result = node.config.resultIsJson
+        ? safeJsonParse(node.config.result)
+        : coerceValue(node.config.result);
+    }
+    if (node.config.inputPath) payload.InputPath = node.config.inputPath;
+    if (node.config.outputPath) payload.OutputPath = node.config.outputPath;
+    if (node.config.resultPath) payload.ResultPath = node.config.resultPath;
+    const params = exportParameters(node.config.parameters || []);
+    if (params) payload.Parameters = params;
+    return payload;
+  }
+
+  function exportChoice(flow, node) {
+    const payload = { Choices: [] };
+    (node.config.choices || []).forEach((choice) => {
+      if (!choice.variable || !choice.operator) return;
+      const rule = { Variable: choice.variable };
+      rule[choice.operator] = coerceValue(choice.value);
+      if (choice.next && flow.nodes[choice.next]) {
+        rule.Next = flow.nodes[choice.next].name;
+      }
+      payload.Choices.push(rule);
+    });
+    if (node.transitions.default && flow.nodes[node.transitions.default]) {
+      payload.Default = flow.nodes[node.transitions.default].name;
+    }
+    return payload;
+  }
+
+  function exportWait(node) {
+    const payload = {};
+    const mode = node.config.mode;
+    if (mode === "seconds") {
+      payload.Seconds = Number(node.config.seconds || 0);
+    } else if (mode === "timestamp") {
+      payload.Timestamp = node.config.timestamp;
+    } else if (mode === "secondsPath") {
+      payload.SecondsPath = node.config.secondsPath;
+    } else if (mode === "timestampPath") {
+      payload.TimestampPath = node.config.timestampPath;
+    }
+    if (node.config.inputPath) payload.InputPath = node.config.inputPath;
+    if (node.config.outputPath) payload.OutputPath = node.config.outputPath;
+    if (node.config.resultPath) payload.ResultPath = node.config.resultPath;
+    return payload;
+  }
+
+  function exportMap(state, node) {
+    const payload = { ItemsPath: node.config.itemsPath || "$.items" };
+    const flowIds = node.branchFlowIds || [];
+    if (flowIds[0] && state.flows[flowIds[0]]) {
+      payload.ItemProcessor = exportFlow(state, state.flows[flowIds[0]]);
+    }
+    if (node.config.resultPath) payload.ResultPath = node.config.resultPath;
+    if (node.config.maxConcurrency) payload.MaxConcurrency = Number(node.config.maxConcurrency);
+    const params = exportParameters(node.config.parameters || []);
+    if (params) payload.Parameters = params;
+    return payload;
+  }
+
+  function exportParallel(state, node) {
+    const branches = [];
+    (node.branchFlowIds || []).forEach((flowId) => {
+      const branch = state.flows[flowId];
+      if (branch) {
+        branches.push(exportFlow(state, branch));
+      }
+    });
+    return { Branches: branches };
+  }
+
+  function exportFail(node) {
+    const payload = {};
+    if (node.config.error) payload.Error = node.config.error;
+    if (node.config.cause) payload.Cause = node.config.cause;
+    return payload;
+  }
+
+  function exportSucceed() {
+    return {};
+  }
+
+  function exportParameters(parameters) {
+    if (!parameters.length) {
+      return null;
+    }
+    const result = {};
+    parameters.forEach((param) => {
+      if (!param.name) return;
+      const key = param.mode === "path" ? ensureSuffix(param.name, ".$") : param.name;
+      result[key] = param.mode === "path"
+        ? param.value
+        : safeJsonParse(param.value, param.value);
+    });
+    return result;
+  }
+
+  function ensureSuffix(value, suffix) {
+    return value.endsWith(suffix) ? value : `${value}${suffix}`;
+  }
+
+  function safeJsonParse(value, fallback) {
+    if (typeof value !== "string") {
+      return value;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return fallback !== undefined ? fallback : trimmed;
+    }
+    if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+      try {
+        return JSON.parse(trimmed);
+      } catch (err) {
+        return fallback !== undefined ? fallback : trimmed;
+      }
+    }
+    if (trimmed === "true" || trimmed === "false") {
+      return trimmed === "true";
+    }
+    if (!Number.isNaN(Number(trimmed))) {
+      return Number(trimmed);
+    }
+    return fallback !== undefined ? fallback : trimmed;
+  }
+
+  function coerceValue(value) {
+    if (value === "" || value === null || value === undefined) {
+      return "";
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed === "true" || trimmed === "false") {
+        return trimmed === "true";
+      }
+      const number = Number(trimmed);
+      if (!Number.isNaN(number) && trimmed !== "") {
+        return number;
+      }
+      return value;
+    }
+    return value;
+  }
+
+  function useToasts(state, dispatch) {
+    useEffect(() => {
+      if (!state.toasts.length) {
+        return;
+      }
+      const timers = state.toasts.map((toast) =>
+        setTimeout(() => {
+          dispatch({ type: "REMOVE_TOAST", id: toast.id });
+        }, 4200)
+      );
+      return () => timers.forEach((timer) => clearTimeout(timer));
+    }, [state.toasts]);
+  }
+
+  function useCatalogs(dispatch) {
+    useEffect(() => {
+      fetchCatalogs(dispatch);
+    }, [dispatch]);
+  }
+
+  function fetchCatalogs(dispatch) {
+    fetch("/api/catalogs")
+      .then((response) => response.json())
+      .then((payload) => {
+        dispatch({
+          type: "SET_CATALOGS",
+          payload: {
+            items: payload.catalogs || [],
+            aggregated: payload.functions || [],
+            supportsRegistry: Boolean(payload.supports_registry)
+          }
+        });
+      })
+      .catch(() => {
+        dispatch({
+          type: "ADD_TOAST",
+          toast: formatToast("Unable to load catalogs", "error")
+        });
+      });
+  }
+
+  function computeEdges(flow) {
+    if (!flow) return [];
+    const edges = [];
+    flow.order.forEach((nodeId) => {
+      const node = flow.nodes[nodeId];
+      if (!node) return;
+      if (node.transitions.next) {
+        edges.push({
+          id: `next-${nodeId}`,
+          from: nodeId,
+          to: node.transitions.next,
+          label: node.type === "Choice" ? "" : "Next"
+        });
+      }
+      if (node.type === "Choice") {
+        (node.config.choices || []).forEach((choice, index) => {
+          if (choice.next) {
+            edges.push({
+              id: `choice-${nodeId}-${index}`,
+              from: nodeId,
+              to: choice.next,
+              label: choice.operator || `Rule ${index + 1}`
+            });
+          }
+        });
+        if (node.transitions.default) {
+          edges.push({
+            id: `choice-default-${nodeId}`,
+            from: nodeId,
+            to: node.transitions.default,
+            label: "Default"
+          });
+        }
+      }
+    });
+    return edges;
+  }
+
+  function getNodeClass(type) {
+    return `node-card node-${type.toLowerCase()}`;
+  }
+
+  function ToastContainer({ toasts }) {
+    if (!toasts.length) return null;
+    return h(
+      'div',
+      { className: 'toast-container' },
+      toasts.map((toast) =>
+        h(
+          'div',
+          { className: `toast ${toast.tone || 'info'}`, key: toast.id },
+          toast.message
+        )
+      )
+    );
+  }
+
+  function AppHeader({ flow, onDownload, onValidate, onOpenInstall, validation }) {
+    return h('header', { className: 'app-header' }, [
+      h('div', { className: 'title-block' }, [
+        h('h1', { className: 'title' }, 'DynaFlow Studio'),
+        h('span', { className: 'tagline' }, flow ? flow.label : 'Workflow')
+      ]),
+      h('div', { className: 'header-actions' }, [
+        h(
+          'button',
+          {
+            onClick: onOpenInstall
+          },
+          'Install catalog'
+        ),
+        h(
+          'button',
+          {
+            onClick: onValidate
+          },
+          validation.status === 'running' ? 'Validating…' : 'Validate flow'
+        ),
+        h(
+          'button',
+          {
+            className: 'primary',
+            onClick: onDownload
+          },
+          'Download JSON'
+        )
+      ])
+    ]);
+  }
+
+  function Sidebar({ catalogs, onRefreshCatalog, onRemoveCatalog }) {
+    return h('aside', { className: 'sidebar' }, [
+      h('div', { className: 'section-header' }, 'Function catalogs'),
+      h('div', { className: 'sidebar-content' }, [
+        h(CatalogList, {
+          catalogs,
+          onRefresh: onRefreshCatalog,
+          onRemove: onRemoveCatalog
+        }),
+        h('div', { className: 'palette' }, [
+          h('div', { className: 'section-header' }, 'Node palette'),
+          h(NodePalette, null)
+        ])
+      ])
+    ]);
+  }
+
+  function CatalogList({ catalogs, onRefresh, onRemove }) {
+    if (!catalogs.length) {
+      return h('div', { className: 'empty-state' }, 'No catalogs registered yet. Install one to bootstrap your tasks.');
+    }
+    return h(
+      Fragment,
+      null,
+      catalogs.map((catalog) =>
+        h('div', { className: 'catalog-card', key: catalog.alias }, [
+          h('div', { className: 'catalog-header' }, [
+            h('strong', null, catalog.alias || catalog.module),
+            catalog.module ? h('div', { className: 'meta' }, catalog.module) : null
+          ]),
+          catalog.metadata && catalog.metadata.source
+            ? h('div', { className: 'meta' }, catalog.metadata.source)
+            : null,
+          catalog.error ? h('div', { className: 'error' }, catalog.error) : null,
+          h('div', { className: 'catalog-actions' }, [
+            h(
+              'button',
+              {
+                onClick: () => onRefresh && onRefresh(catalog.alias)
+              },
+              'Refresh'
+            ),
+            h(
+              'button',
+              {
+                onClick: () => onRemove && onRemove(catalog.alias)
+              },
+              'Remove'
+            )
+          ])
+        ])
+      )
+    );
+  }
+
+  function NodePalette() {
+    return h(
+      'div',
+      null,
+      NODE_TYPES.map((node) =>
+        h(
+          'div',
+          {
+            className: 'node-type',
+            key: node.id,
+            draggable: true,
+            onDragStart: (event) => {
+              event.dataTransfer.effectAllowed = 'copy';
+              event.dataTransfer.setData('application/x-node-type', node.id);
+            }
+          },
+          [
+            h('span', null, node.label),
+            h('small', { className: 'subtitle' }, node.description)
+          ]
+        )
+      )
+    );
+  }
+
+  function CanvasView({
+    flow,
+    selection,
+    canvasRef,
+    edges,
+    nodeRects,
+    onDropNode,
+    onSelectNode,
+    onMoveNode,
+    onOpenFlow
+  }) {
+    const handleDrop = (event) => {
+      event.preventDefault();
+      const nodeType = event.dataTransfer.getData('application/x-node-type');
+      if (!nodeType || !flow) return;
+      const rect = canvasRef.current.getBoundingClientRect();
+      const position = {
+        x: event.clientX - rect.left - 100,
+        y: event.clientY - rect.top - 40
+      };
+      onDropNode(nodeType, position);
+    };
+
+    const handleDragOver = (event) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'copy';
+    };
+
+    return h('div', { className: 'canvas', onDrop: handleDrop, onDragOver: handleDragOver }, [
+      h(LinkLayer, { edges, rects: nodeRects }),
+      h(
+        'div',
+        { className: 'canvas-inner', ref: canvasRef },
+        flow && flow.order.length
+          ? flow.order.map((nodeId) => {
+              const node = flow.nodes[nodeId];
+              return h(NodeCard, {
+                key: node.id,
+                node,
+                selected: selection && selection.nodeId === node.id,
+                onSelect: onSelectNode,
+                onMove: onMoveNode,
+                onOpenFlow
+              });
+            })
+          : h('div', { className: 'empty-state' }, 'Drag a node from the palette to begin designing your flow.')
+      )
+    ]);
+  }
+
+  function NodeCard({ node, selected, onSelect, onMove, onOpenFlow }) {
+    const ref = useRef(null);
+
+    const handleDoubleClick = useCallback(() => {
+      if ((node.type === 'Map' || node.type === 'Parallel') && node.branchFlowIds.length) {
+        onOpenFlow(node.branchFlowIds[0]);
+      }
+    }, [node, onOpenFlow]);
+
+    useEffect(() => {
+      const element = ref.current;
+      if (!element) return;
+      const handlePointerDown = (event) => {
+        event.preventDefault();
+        onSelect(node.id);
+        const startX = event.clientX;
+        const startY = event.clientY;
+        const initial = { ...node.position };
+        const move = (moveEvent) => {
+          moveEvent.preventDefault();
+          const dx = moveEvent.clientX - startX;
+          const dy = moveEvent.clientY - startY;
+          onMove(node.id, { x: initial.x + dx, y: initial.y + dy });
+        };
+        const stop = () => {
+          window.removeEventListener('pointermove', move);
+          window.removeEventListener('pointerup', stop);
+        };
+        window.addEventListener('pointermove', move);
+        window.addEventListener('pointerup', stop);
+      };
+      element.addEventListener('pointerdown', handlePointerDown);
+      return () => {
+        element.removeEventListener('pointerdown', handlePointerDown);
+      };
+    }, [node.id, node.position.x, node.position.y, onMove, onSelect]);
+
+    const className = `${getNodeClass(node.type)}${selected ? ' selected' : ''}`;
+
+    return h(
+      'div',
+      {
+        className,
+        ref,
+        'data-node-id': node.id,
+        style: {
+          left: `${node.position.x}px`,
+          top: `${node.position.y}px`
+        },
+        onDoubleClick: handleDoubleClick
+      },
+      [
+        h('div', { className: 'title' }, [
+          h('strong', null, node.name),
+          h('span', { className: 'tag' }, node.type)
+        ]),
+        node.comment ? h('div', { className: 'subtitle' }, node.comment) : null,
+        (node.type === 'Map' || node.type === 'Parallel') && node.branchFlowIds.length
+          ? h(
+              'button',
+              {
+                className: 'open-branch',
+                onClick: () => onOpenFlow(node.branchFlowIds[0])
+              },
+              'Open'
+            )
+          : null
+      ]
+    );
+  }
+
+  function LinkLayer({ edges, rects }) {
+    if (!edges.length) return null;
+    return h(
+      'svg',
+      { className: 'link-canvas' },
+      edges.map((edge) => {
+        const source = rects[edge.from];
+        const target = rects[edge.to];
+        if (!source || !target) {
+          return null;
+        }
+        const startX = source.left + source.width;
+        const startY = source.top + source.height / 2;
+        const endX = target.left;
+        const endY = target.top + target.height / 2;
+        const midX = startX + (endX - startX) * 0.5;
+        const path = `M ${startX} ${startY} C ${midX} ${startY}, ${midX} ${endY}, ${endX} ${endY}`;
+        return h(
+          'g',
+          { key: edge.id },
+          [
+            h('path', {
+              d: path,
+              fill: 'none',
+              stroke: 'rgba(148,163,184,0.35)',
+              'stroke-width': 2
+            }),
+            h('circle', {
+              cx: endX,
+              cy: endY,
+              r: 4,
+              fill: 'rgba(56,189,248,0.85)'
+            }),
+            edge.label
+              ? h(
+                  'text',
+                  {
+                    x: midX,
+                    y: startY + (endY - startY) * 0.5 - 6,
+                    className: 'edge-label'
+                  },
+                  edge.label
+                )
+              : null
+          ]
+        );
+      })
+    );
+  }
+
+  function ConfigPanel({
+    flows,
+    currentFlow,
+    selection,
+    dispatch,
+    aggregatedFunctions,
+    onNavigateFlow
+  }) {
+    const node = selection && currentFlow ? currentFlow.nodes[selection.nodeId] : null;
+    return h('aside', { className: 'config-panel' }, [
+      h('div', { className: 'section-header' }, 'Configuration'),
+      h(
+        'div',
+        { className: 'config-content' },
+        node && currentFlow
+          ? [
+              h(FlowBreadcrumb, { flow: currentFlow, flows, onNavigate: onNavigateFlow }),
+              h(NodeGeneralSettings, {
+                flow: currentFlow,
+                node,
+                dispatch
+              }),
+              renderNodeEditor({
+                node,
+                flow: currentFlow,
+                dispatch,
+                aggregatedFunctions,
+                flows,
+                onNavigateFlow
+              })
+            ]
+          : h('div', { className: 'empty-state' }, 'Select a node to configure its behaviour.')
+      )
+    ]);
+  }
+
+  function FlowBreadcrumb({ flow, flows, onNavigate }) {
+    const items = [];
+    let cursor = flow;
+    while (cursor) {
+      items.unshift(cursor);
+      cursor = cursor.parent ? flows[cursor.parent.flowId] : null;
+    }
+    return h(
+      'div',
+      { className: 'flow-breadcrumb' },
+      items.map((item, index) =>
+        h(
+          'button',
+          {
+            key: item.id,
+            className: index === items.length - 1 ? 'active' : '',
+            onClick: () => onNavigate(item.id)
+          },
+          item.label || item.id
+        )
+      )
+    );
+  }
+
+  function supportsNextTransition(type) {
+    return ['Task', 'Pass', 'Wait', 'Map', 'Parallel'].includes(type);
+  }
+
+  function NodeGeneralSettings({ flow, node, dispatch }) {
+    const nextOptions = flow.order
+      .filter((id) => id !== node.id)
+      .map((id) => ({ id, label: flow.nodes[id].name }));
+
+    const handleNameChange = (event) => {
+      dispatch({
+        type: 'UPDATE_NODE',
+        flowId: flow.id,
+        nodeId: node.id,
+        changes: { name: event.target.value }
+      });
+    };
+
+    const handleCommentChange = (event) => {
+      dispatch({
+        type: 'UPDATE_NODE',
+        flowId: flow.id,
+        nodeId: node.id,
+        changes: { comment: event.target.value }
+      });
+    };
+
+    const toggleEnd = () => {
+      dispatch({
+        type: 'UPDATE_NODE',
+        flowId: flow.id,
+        nodeId: node.id,
+        changes: {
+          transitions: {
+            end: !node.transitions.end,
+            next: node.transitions.end ? node.transitions.next : null
+          }
+        }
+      });
+    };
+
+    const handleNextChange = (event) => {
+      dispatch({
+        type: 'UPDATE_NODE',
+        flowId: flow.id,
+        nodeId: node.id,
+        changes: { transitions: { next: event.target.value || null } }
+      });
+    };
+
+    const removeNode = () => {
+      if (window.confirm(`Remove node ${node.name}?`)) {
+        dispatch({ type: 'REMOVE_NODE', flowId: flow.id, nodeId: node.id });
+      }
+    };
+
+    const setAsStart = () => {
+      dispatch({ type: 'SET_FLOW_START', flowId: flow.id, nodeId: node.id });
+    };
+
+    return h(Fragment, null, [
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'State name'),
+        h('input', {
+          value: node.name,
+          onInput: handleNameChange
+        })
+      ]),
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Comment'),
+        h('textarea', {
+          value: node.comment || '',
+          onInput: handleCommentChange,
+          placeholder: 'Optional description'
+        })
+      ]),
+      h('div', { className: 'button-line' }, [
+        h(
+          'button',
+          {
+            onClick: setAsStart,
+            disabled: flow.startNodeId === node.id
+          },
+          flow.startNodeId === node.id ? 'Start state' : 'Mark as start'
+        ),
+        h(
+          'button',
+          {
+            onClick: removeNode,
+            style: { background: 'rgba(248,113,113,0.2)', color: 'rgba(248,113,113,0.9)' }
+          },
+          'Remove'
+        )
+      ]),
+      supportsNextTransition(node.type)
+        ? h('div', { className: 'form-field' }, [
+            h('label', null, 'Next state'),
+            h(
+              'select',
+              {
+                value: node.transitions.next || '',
+                disabled: node.transitions.end,
+                onChange: handleNextChange
+              },
+              [
+                h('option', { value: '' }, '— None —'),
+                ...nextOptions.map((option) =>
+                  h('option', { key: option.id, value: option.id }, option.label)
+                )
+              ]
+            )
+          ])
+        : null,
+      h('div', { className: 'switch-row' }, [
+        h('label', null, 'Marks end of the flow'),
+        h('div', {
+          className: 'toggle',
+          'data-active': node.transitions.end ? 'true' : 'false',
+          onClick: toggleEnd
+        })
+      ])
+    ]);
+  }
+
+  function renderNodeEditor({ node, flow, dispatch, aggregatedFunctions, flows, onNavigateFlow }) {
+    switch (node.type) {
+      case 'Task':
+        return h(TaskEditor, { node, flowId: flow.id, dispatch, aggregatedFunctions });
+      case 'Pass':
+        return h(PassEditor, { node, flowId: flow.id, dispatch });
+      case 'Choice':
+        return h(ChoiceEditor, { node, flow, dispatch });
+      case 'Wait':
+        return h(WaitEditor, { node, flowId: flow.id, dispatch });
+      case 'Map':
+        return h(MapEditor, { node, flowId: flow.id, dispatch, flows, onNavigateFlow });
+      case 'Parallel':
+        return h(ParallelEditor, { node, flowId: flow.id, dispatch, flows, onNavigateFlow });
+      case 'Fail':
+        return h(FailEditor, { node, flowId: flow.id, dispatch });
+      case 'Succeed':
+        return h(SucceedEditor, { node });
+      default:
+        return h('div', null, 'No editor available for this state.');
+    }
+  }
+
+  function ParametersEditor({ parameters, onChange, title }) {
+    const addParameter = () => {
+      const next = parameters.concat({
+        id: createId('param'),
+        name: '',
+        value: '',
+        mode: 'value'
+      });
+      onChange(next);
+    };
+
+    const updateParameter = (index, changes) => {
+      const next = parameters.map((param, idx) => (idx === index ? { ...param, ...changes } : param));
+      onChange(next);
+    };
+
+    const removeParameter = (index) => {
+      const next = parameters.filter((_, idx) => idx !== index);
+      onChange(next);
+    };
+
+    return h('div', { className: 'form-field' }, [
+      h('label', null, title || 'Parameters'),
+      h(
+        'div',
+        { className: 'parameters' },
+        [
+          parameters.length
+            ? parameters.map((param, index) =>
+                h('div', { className: 'parameter-item', key: param.id }, [
+                  h('input', {
+                    placeholder: 'Key',
+                    value: param.name,
+                    onInput: (event) => updateParameter(index, { name: event.target.value })
+                  }),
+                  h('select', {
+                    value: param.mode,
+                    onChange: (event) => updateParameter(index, { mode: event.target.value })
+                  }, [
+                    h('option', { value: 'value' }, 'Value'),
+                    h('option', { value: 'path' }, 'JSONPath')
+                  ]),
+                  h('input', {
+                    placeholder: param.mode === 'path' ? '$.path' : 'Value',
+                    value: param.value,
+                    onInput: (event) => updateParameter(index, { value: event.target.value })
+                  }),
+                  h(
+                    'button',
+                    { onClick: () => removeParameter(index), title: 'Remove parameter' },
+                    '×'
+                  )
+                ])
+              )
+            : h('div', { className: 'empty-state' }, 'No parameters defined.')
+        ].concat([
+          h(
+            'button',
+            {
+              onClick: addParameter,
+              style: {
+                marginTop: '12px',
+                width: '100%'
+              }
+            },
+            'Add parameter'
+          )
+        ])
+      )
+    ]);
+  }
+
+  function TaskEditor({ node, flowId, dispatch, aggregatedFunctions }) {
+    const config = node.config;
+
+    const updateFunctionFields = (fields) => {
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId,
+        nodeId: node.id,
+        updater: (cfg) => {
+          cfg.functionFields = fields;
+        }
+      });
+    };
+
+    const updateParameters = (parameters) => {
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId,
+        nodeId: node.id,
+        updater: (cfg) => {
+          cfg.parameters = parameters;
+        }
+      });
+    };
+
+    const ensureVersionField = (fields, versions) => {
+      let nextFields = fields.slice();
+      const versionIndex = nextFields.findIndex((field) => field.key === 'Version');
+      if (versions && versions.length) {
+        if (versionIndex === -1) {
+          nextFields.push({ id: createId('fn'), key: 'Version', value: versions[0].version || '' });
+        } else if (!nextFields[versionIndex].value) {
+          nextFields[versionIndex].value = versions[0].version || '';
+        }
+      } else if (versionIndex !== -1) {
+        nextFields.splice(versionIndex, 1);
+      }
+      return nextFields;
+    };
+
+    const handleFunctionSelect = (event) => {
+      const value = event.target.value;
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId,
+        nodeId: node.id,
+        updater: (cfg) => {
+          const fields = cfg.functionFields.slice();
+          const nameField = fields.find((field) => field.key === 'Name');
+          if (nameField) {
+            nameField.value = value;
+          } else {
+            fields.unshift({ id: createId('fn'), key: 'Name', value, required: true });
+          }
+          const selected = aggregatedFunctions.find((fn) => fn.name === value);
+          cfg.functionFields = ensureVersionField(fields, selected ? selected.versions : null);
+        }
+      });
+    };
+
+    const handleVersionSelect = (event) => {
+      const value = event.target.value;
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId,
+        nodeId: node.id,
+        updater: (cfg) => {
+          cfg.functionFields = cfg.functionFields.map((field) =>
+            field.key === 'Version' ? { ...field, value } : field
+          );
+        }
+      });
+    };
+
+    const handleFieldChange = (index, changes) => {
+      const next = config.functionFields.map((field, idx) =>
+        idx === index ? { ...field, ...changes } : field
+      );
+      updateFunctionFields(next);
+    };
+
+    const addField = () => {
+      updateFunctionFields(
+        config.functionFields.concat({ id: createId('fn'), key: '', value: '' })
+      );
+    };
+
+    const removeField = (index) => {
+      const field = config.functionFields[index];
+      if (field && field.required) {
+        return;
+      }
+      updateFunctionFields(config.functionFields.filter((_, idx) => idx !== index));
+    };
+
+    const nameField = config.functionFields.find((field) => field.key === 'Name');
+    const selectedFunction = nameField
+      ? aggregatedFunctions.find((item) => item.name === nameField.value)
+      : null;
+    const versions = selectedFunction ? selectedFunction.versions || [] : [];
+
+    const updatePathField = (key) => (event) => {
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId,
+        nodeId: node.id,
+        updater: (cfg) => {
+          cfg[key] = event.target.value;
+        }
+      });
+    };
+
+    return h(Fragment, null, [
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Function catalog'),
+        h(
+          'select',
+          {
+            value: nameField ? nameField.value : '',
+            onChange: handleFunctionSelect
+          },
+          [
+            h('option', { value: '' }, '— Select function —'),
+            ...aggregatedFunctions.map((fn) =>
+              h('option', { key: fn.name, value: fn.name }, fn.name)
+            )
+          ]
+        )
+      ]),
+      versions.length
+        ? h('div', { className: 'form-field' }, [
+            h('label', null, 'Version'),
+            h(
+              'select',
+              {
+                value: config.functionFields.find((field) => field.key === 'Version')?.value || '',
+                onChange: handleVersionSelect
+              },
+              versions.map((version) =>
+                h('option', { key: version.version, value: version.version }, version.version)
+              )
+            )
+          ])
+        : null,
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Function properties'),
+        h(
+          'div',
+          { className: 'parameters' },
+          [
+            config.functionFields.map((field, index) =>
+              h('div', { className: 'parameter-item', key: field.id }, [
+                h('input', {
+                  value: field.key,
+                  onInput: (event) => handleFieldChange(index, { key: event.target.value }),
+                  readOnly: field.required,
+                  placeholder: 'Property'
+                }),
+                h('input', {
+                  value: field.value,
+                  onInput: (event) => handleFieldChange(index, { value: event.target.value }),
+                  placeholder: 'Value'
+                }),
+                h(
+                  'button',
+                  {
+                    onClick: () => removeField(index),
+                    disabled: field.required
+                  },
+                  '×'
+                )
+              ])
+            ),
+            h(
+              'button',
+              {
+                onClick: addField,
+                style: { marginTop: '12px', width: '100%' }
+              },
+              'Add property'
+            )
+          ]
+        )
+      ]),
+      h(ParametersEditor, {
+        parameters: config.parameters,
+        onChange: updateParameters,
+        title: 'Parameters'
+      }),
+      h('div', { className: 'grid-row' }, [
+        h('div', { className: 'form-field' }, [
+          h('label', null, 'InputPath'),
+          h('input', {
+            value: config.inputPath || '',
+            onInput: updatePathField('inputPath'),
+            placeholder: '$'
+          })
+        ]),
+        h('div', { className: 'form-field' }, [
+          h('label', null, 'OutputPath'),
+          h('input', {
+            value: config.outputPath || '',
+            onInput: updatePathField('outputPath'),
+            placeholder: '$'
+          })
+        ])
+      ]),
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'ResultPath'),
+        h('input', {
+          value: config.resultPath || '',
+          onInput: updatePathField('resultPath'),
+          placeholder: '$'
+        })
+      ]),
+      h('div', { className: 'grid-row' }, [
+        h('div', { className: 'form-field' }, [
+          h('label', null, 'Heartbeat (seconds)'),
+          h('input', {
+            value: config.heartbeatSeconds || '',
+            onInput: updatePathField('heartbeatSeconds'),
+            type: 'number',
+            min: '0'
+          })
+        ]),
+        h('div', { className: 'form-field' }, [
+          h('label', null, 'Timeout (seconds)'),
+          h('input', {
+            value: config.timeoutSeconds || '',
+            onInput: updatePathField('timeoutSeconds'),
+            type: 'number',
+            min: '0'
+          })
+        ])
+      ])
+    ]);
+  }
+
+  function PassEditor({ node, flowId, dispatch }) {
+    const config = node.config;
+
+    const updateConfig = (changes) => {
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId,
+        nodeId: node.id,
+        updater: (cfg) => Object.assign(cfg, changes)
+      });
+    };
+
+    return h(Fragment, null, [
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Result payload'),
+        h('textarea', {
+          value: config.result || '',
+          onInput: (event) => updateConfig({ result: event.target.value }),
+          placeholder: config.resultIsJson ? '{ "key": "value" }' : 'Plain value'
+        })
+      ]),
+      h('div', { className: 'switch-row' }, [
+        h('label', null, 'Interpret as JSON'),
+        h('div', {
+          className: 'toggle',
+          'data-active': config.resultIsJson ? 'true' : 'false',
+          onClick: () => updateConfig({ resultIsJson: !config.resultIsJson })
+        })
+      ]),
+      h(ParametersEditor, {
+        parameters: config.parameters,
+        onChange: (parameters) => updateConfig({ parameters }),
+        title: 'Parameters'
+      }),
+      h('div', { className: 'grid-row' }, [
+        h('div', { className: 'form-field' }, [
+          h('label', null, 'InputPath'),
+          h('input', {
+            value: config.inputPath || '',
+            onInput: (event) => updateConfig({ inputPath: event.target.value }),
+            placeholder: '$'
+          })
+        ]),
+        h('div', { className: 'form-field' }, [
+          h('label', null, 'OutputPath'),
+          h('input', {
+            value: config.outputPath || '',
+            onInput: (event) => updateConfig({ outputPath: event.target.value }),
+            placeholder: '$'
+          })
+        ])
+      ]),
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'ResultPath'),
+        h('input', {
+          value: config.resultPath || '',
+          onInput: (event) => updateConfig({ resultPath: event.target.value }),
+          placeholder: '$'
+        })
+      ])
+    ]);
+  }
+
+  function ChoiceEditor({ node, flow, dispatch }) {
+    const config = node.config;
+    const updateChoices = (choices) => {
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId: flow.id,
+        nodeId: node.id,
+        updater: (cfg) => {
+          cfg.choices = choices;
+        }
+      });
+    };
+
+    const addChoice = () => {
+      updateChoices(
+        (config.choices || []).concat({
+          id: createId('choice'),
+          variable: '',
+          operator: 'StringEquals',
+          value: '',
+          next: null
+        })
+      );
+    };
+
+    const updateChoice = (index, changes) => {
+      updateChoices(
+        config.choices.map((choice, idx) => (idx === index ? { ...choice, ...changes } : choice))
+      );
+    };
+
+    const removeChoice = (index) => {
+      updateChoices(config.choices.filter((_, idx) => idx !== index));
+    };
+
+    const updateDefault = (event) => {
+      dispatch({
+        type: 'UPDATE_NODE',
+        flowId: flow.id,
+        nodeId: node.id,
+        changes: { transitions: { default: event.target.value || null } }
+      });
+    };
+
+    const nextOptions = flow.order
+      .filter((id) => id !== node.id)
+      .map((id) => ({ id, label: flow.nodes[id].name }));
+
+    return h(Fragment, null, [
+      h('div', { className: 'notice warning' }, 'Define comparison rules. The first matching rule determines the branch execution.'),
+      (config.choices || []).map((choice, index) =>
+        h('div', { className: 'parameters', key: choice.id }, [
+          h('div', { className: 'form-field' }, [
+            h('label', null, 'Variable'),
+            h('input', {
+              value: choice.variable || '',
+              onInput: (event) => updateChoice(index, { variable: event.target.value }),
+              placeholder: '$.path'
+            })
+          ]),
+          h('div', { className: 'form-field' }, [
+            h('label', null, 'Operator'),
+            h(
+              'select',
+              {
+                value: choice.operator,
+                onChange: (event) => updateChoice(index, { operator: event.target.value })
+              },
+              CHOICE_OPERATORS.map((operator) =>
+                h('option', { key: operator, value: operator }, operator)
+              )
+            )
+          ]),
+          h('div', { className: 'form-field' }, [
+            h('label', null, 'Value'),
+            h('input', {
+              value: choice.value || '',
+              onInput: (event) => updateChoice(index, { value: event.target.value })
+            })
+          ]),
+          h('div', { className: 'form-field' }, [
+            h('label', null, 'Next'),
+            h(
+              'select',
+              {
+                value: choice.next || '',
+                onChange: (event) => updateChoice(index, { next: event.target.value || null })
+              },
+              [
+                h('option', { value: '' }, '— Select —'),
+                ...nextOptions.map((option) =>
+                  h('option', { key: option.id, value: option.id }, option.label)
+                )
+              ]
+            )
+          ]),
+          h(
+            'button',
+            {
+              onClick: () => removeChoice(index),
+              style: { marginTop: '8px', background: 'rgba(248,113,113,0.2)', color: 'rgba(248,113,113,0.9)' }
+            },
+            'Remove rule'
+          )
+        ])
+      ),
+      h(
+        'button',
+        {
+          onClick: addChoice,
+          style: { marginTop: '12px', width: '100%' }
+        },
+        'Add rule'
+      ),
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Default branch'),
+        h(
+          'select',
+          {
+            value: node.transitions.default || '',
+            onChange: updateDefault
+          },
+          [
+            h('option', { value: '' }, '— None —'),
+            ...nextOptions.map((option) =>
+              h('option', { key: option.id, value: option.id }, option.label)
+            )
+          ]
+        )
+      ])
+    ]);
+  }
+
+  function WaitEditor({ node, flowId, dispatch }) {
+    const config = node.config;
+    const updateConfig = (changes) => {
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId,
+        nodeId: node.id,
+        updater: (cfg) => Object.assign(cfg, changes)
+      });
+    };
+
+    const renderModeField = () => {
+      switch (config.mode) {
+        case 'seconds':
+          return h('input', {
+            type: 'number',
+            min: '0',
+            value: config.seconds || '',
+            onInput: (event) => updateConfig({ seconds: event.target.value }),
+            placeholder: '10'
+          });
+        case 'timestamp':
+          return h('input', {
+            type: 'text',
+            value: config.timestamp || '',
+            onInput: (event) => updateConfig({ timestamp: event.target.value }),
+            placeholder: '2024-01-01T00:00:00Z'
+          });
+        case 'secondsPath':
+          return h('input', {
+            type: 'text',
+            value: config.secondsPath || '',
+            onInput: (event) => updateConfig({ secondsPath: event.target.value }),
+            placeholder: '$.wait_time'
+          });
+        case 'timestampPath':
+          return h('input', {
+            type: 'text',
+            value: config.timestampPath || '',
+            onInput: (event) => updateConfig({ timestampPath: event.target.value }),
+            placeholder: '$.target_date'
+          });
+        default:
+          return null;
+      }
+    };
+
+    return h(Fragment, null, [
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Mode'),
+        h(
+          'select',
+          {
+            value: config.mode,
+            onChange: (event) => updateConfig({ mode: event.target.value })
+          },
+          WAIT_MODES.map((mode) => h('option', { key: mode.id, value: mode.id }, mode.label))
+        )
+      ]),
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Value'),
+        renderModeField()
+      ]),
+      h('div', { className: 'grid-row' }, [
+        h('div', { className: 'form-field' }, [
+          h('label', null, 'InputPath'),
+          h('input', {
+            value: config.inputPath || '',
+            onInput: (event) => updateConfig({ inputPath: event.target.value })
+          })
+        ]),
+        h('div', { className: 'form-field' }, [
+          h('label', null, 'OutputPath'),
+          h('input', {
+            value: config.outputPath || '',
+            onInput: (event) => updateConfig({ outputPath: event.target.value })
+          })
+        ])
+      ]),
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'ResultPath'),
+        h('input', {
+          value: config.resultPath || '',
+          onInput: (event) => updateConfig({ resultPath: event.target.value })
+        })
+      ])
+    ]);
+  }
+
+  function MapEditor({ node, flowId, dispatch, flows, onNavigateFlow }) {
+    const config = node.config;
+    const updateConfig = (changes) => {
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId,
+        nodeId: node.id,
+        updater: (cfg) => Object.assign(cfg, changes)
+      });
+    };
+
+    const iteratorFlowId = node.branchFlowIds[0];
+    const iteratorFlow = iteratorFlowId ? flows[iteratorFlowId] : null;
+
+    return h(Fragment, null, [
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'ItemsPath'),
+        h('input', {
+          value: config.itemsPath || '',
+          onInput: (event) => updateConfig({ itemsPath: event.target.value }),
+          placeholder: '$.items'
+        })
+      ]),
+      h(ParametersEditor, {
+        parameters: config.parameters,
+        onChange: (parameters) => updateConfig({ parameters }),
+        title: 'Parameters'
+      }),
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'ResultPath'),
+        h('input', {
+          value: config.resultPath || '',
+          onInput: (event) => updateConfig({ resultPath: event.target.value })
+        })
+      ]),
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Max concurrency'),
+        h('input', {
+          type: 'number',
+          min: '0',
+          value: config.maxConcurrency || '',
+          onInput: (event) => updateConfig({ maxConcurrency: event.target.value })
+        })
+      ]),
+      iteratorFlow
+        ? h('div', { className: 'branch-card' }, [
+            h('span', null, iteratorFlow.label || 'Iterator'),
+            h(
+              'button',
+              { onClick: () => onNavigateFlow(iteratorFlow.id) },
+              'Edit iterator'
+            )
+          ])
+        : null
+    ]);
+  }
+
+  function ParallelEditor({ node, flowId, dispatch, flows, onNavigateFlow }) {
+    const branches = node.branchFlowIds || [];
+
+    const addBranch = () => {
+      dispatch({ type: 'ADD_PARALLEL_BRANCH', flowId, nodeId: node.id });
+    };
+
+    const removeBranch = (index) => {
+      dispatch({ type: 'REMOVE_PARALLEL_BRANCH', flowId, nodeId: node.id, index });
+    };
+
+    return h(Fragment, null, [
+      branches.length
+        ? branches.map((branchId, index) => {
+            const branch = flows[branchId];
+            return h('div', { className: 'branch-card', key: branchId }, [
+              h('span', null, branch ? branch.label : `Branch ${index + 1}`),
+              h('div', null, [
+                h(
+                  'button',
+                  { onClick: () => onNavigateFlow(branchId) },
+                  'Open'
+                ),
+                branches.length > 1
+                  ? h(
+                      'button',
+                      {
+                        onClick: () => removeBranch(index),
+                        style: {
+                          marginLeft: '8px',
+                          background: 'rgba(248,113,113,0.2)',
+                          color: 'rgba(248,113,113,0.9)'
+                        }
+                      },
+                      'Remove'
+                    )
+                  : null
+              ])
+            ]);
+          })
+        : h('div', { className: 'empty-state' }, 'No branches defined yet.'),
+      h(
+        'button',
+        {
+          onClick: addBranch,
+          style: { marginTop: '12px', width: '100%' }
+        },
+        'Add branch'
+      )
+    ]);
+  }
+
+  function FailEditor({ node, flowId, dispatch }) {
+    const config = node.config;
+    const updateConfig = (changes) => {
+      dispatch({
+        type: 'UPDATE_NODE_CONFIG',
+        flowId,
+        nodeId: node.id,
+        updater: (cfg) => Object.assign(cfg, changes)
+      });
+    };
+
+    return h(Fragment, null, [
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Error code'),
+        h('input', {
+          value: config.error || '',
+          onInput: (event) => updateConfig({ error: event.target.value })
+        })
+      ]),
+      h('div', { className: 'form-field' }, [
+        h('label', null, 'Cause'),
+        h('textarea', {
+          value: config.cause || '',
+          onInput: (event) => updateConfig({ cause: event.target.value })
+        })
+      ])
+    ]);
+  }
+
+  function SucceedEditor() {
+    return h('div', { className: 'notice' }, 'This state marks the flow as completed successfully. No additional configuration is required.');
+  }
+
+  function InstallCatalogModal({ onClose, onInstall, pending, error }) {
+    const [form, setForm] = useState({
+      pipUrl: '',
+      alias: '',
+      module: '',
+      attribute: 'function_catalog',
+      authType: 'none',
+      username: '',
+      password: '',
+      token: ''
+    });
+
+    const updateField = (key, value) => {
+      setForm({ ...form, [key]: value });
+    };
+
+    const submit = (event) => {
+      event.preventDefault();
+      onInstall(form);
+    };
+
+    return h('div', { className: 'modal-backdrop' }, [
+      h(
+        'form',
+        { className: 'modal', onSubmit: submit },
+        [
+          h('header', null, 'Install function catalog'),
+          h(
+            'div',
+            { className: 'modal-body' },
+            [
+              h('div', { className: 'form-field' }, [
+                h('label', null, 'Repository URL or pip spec'),
+                h('input', {
+                  required: true,
+                  value: form.pipUrl,
+                onInput: (event) => updateField('pipUrl', event.target.value),
+                placeholder: 'git+https://...#egg=package'
+              })
+            ]),
+            h('div', { className: 'grid-row' }, [
+              h('div', { className: 'form-field' }, [
+                h('label', null, 'Alias (optional)'),
+                h('input', {
+                  value: form.alias,
+                  onInput: (event) => updateField('alias', event.target.value)
+                })
+              ]),
+              h('div', { className: 'form-field' }, [
+                h('label', null, 'Module name'),
+                h('input', {
+                  value: form.module,
+                  onInput: (event) => updateField('module', event.target.value),
+                  placeholder: 'package.module'
+                })
+              ])
+            ]),
+            h('div', { className: 'form-field' }, [
+              h('label', null, 'Attribute'),
+              h('input', {
+                value: form.attribute,
+                onInput: (event) => updateField('attribute', event.target.value)
+              })
+            ]),
+            h('div', { className: 'form-field' }, [
+              h('label', null, 'Authentication'),
+              h(
+                'select',
+                {
+                  value: form.authType,
+                  onChange: (event) => updateField('authType', event.target.value)
+                },
+                [
+                  h('option', { value: 'none' }, 'None'),
+                  h('option', { value: 'basic' }, 'Username & password'),
+                  h('option', { value: 'token' }, 'Token')
+                ]
+              )
+            ]),
+            form.authType === 'basic'
+              ? h('div', { className: 'grid-row' }, [
+                  h('div', { className: 'form-field' }, [
+                    h('label', null, 'Username'),
+                    h('input', {
+                      value: form.username,
+                      onInput: (event) => updateField('username', event.target.value)
+                    })
+                  ]),
+                  h('div', { className: 'form-field' }, [
+                    h('label', null, 'Password'),
+                    h('input', {
+                      type: 'password',
+                      value: form.password,
+                      onInput: (event) => updateField('password', event.target.value)
+                    })
+                  ])
+                ])
+              : null,
+            form.authType === 'token'
+              ? h('div', { className: 'form-field' }, [
+                  h('label', null, 'Access token'),
+                  h('input', {
+                    value: form.token,
+                    onInput: (event) => updateField('token', event.target.value)
+                  })
+                ])
+              : null,
+              error ? h('div', { className: 'notice danger' }, error) : null,
+              h('div', { style: { height: '1px' } })
+            ]
+          ),
+          h('footer', null, [
+            h(
+              'button',
+              { type: 'button', className: 'ghost', onClick: onClose },
+              'Cancel'
+            ),
+            h(
+              'button',
+              { type: 'submit', className: 'primary', disabled: pending },
+              pending ? 'Installing…' : 'Install'
+            )
+          ])
+        ]
+      )
+    ]);
+  }
+
+  function ValidationSummary({ validation }) {
+    if (validation.status !== 'invalid' || !validation.errors.length) {
+      return null;
+    }
+    return h(
+      'div',
+      { className: 'validation-panel' },
+      validation.errors.map((error, index) =>
+        h('div', { className: 'error-item', key: index }, [
+          h('strong', null, error.message),
+          error.path && error.path.length
+            ? h('span', null, `Path: ${error.path.join(' > ')}`)
+            : null,
+          error.validator ? h('span', null, `Validator: ${error.validator}`) : null
+        ])
+      )
+    );
+  }
+
+  function App() {
+    const [state, dispatch] = useReducer(reducer, null, createInitialState);
+    const [nodeRects, setNodeRects] = useState({});
+    const [installPending, setInstallPending] = useState(false);
+    const [installError, setInstallError] = useState('');
+    const canvasRef = useRef(null);
+    const flow = state.flows[state.currentFlowId];
+
+    useCatalogs(dispatch);
+    useToasts(state, dispatch);
+
+    useEffect(() => {
+      const container = canvasRef.current;
+      if (!container) return;
+      const parentRect = container.getBoundingClientRect();
+      const rects = {};
+      container.querySelectorAll('[data-node-id]').forEach((element) => {
+        const id = element.getAttribute('data-node-id');
+        const bounds = element.getBoundingClientRect();
+        rects[id] = {
+          left: bounds.left - parentRect.left,
+          top: bounds.top - parentRect.top,
+          width: bounds.width,
+          height: bounds.height
+        };
+      });
+      setNodeRects(rects);
+    }, [state.currentFlowId, state.revision, flow ? flow.order.length : 0]);
+
+    const edges = useMemo(() => computeEdges(flow), [flow, state.revision]);
+
+    const handleDropNode = useCallback(
+      (type, position) => {
+        if (!flow) return;
+        dispatch({ type: 'ADD_NODE', flowId: flow.id, nodeType: type, position });
+      },
+      [dispatch, flow]
+    );
+
+    const handleSelectNode = useCallback(
+      (nodeId) => {
+        if (!flow) return;
+        dispatch({ type: 'SET_SELECTION', selection: { flowId: flow.id, nodeId } });
+      },
+      [dispatch, flow]
+    );
+
+    const handleMoveNode = useCallback(
+      (nodeId, position) => {
+        if (!flow) return;
+        dispatch({ type: 'UPDATE_NODE_POSITION', flowId: flow.id, nodeId, position });
+      },
+      [dispatch, flow]
+    );
+
+    const handleNavigateFlow = useCallback(
+      (flowId) => {
+        dispatch({ type: 'NAVIGATE_FLOW', flowId });
+      },
+      [dispatch]
+    );
+
+    const handleDownload = () => {
+      const payload = buildFlowExport(state);
+      const blob = new Blob([JSON.stringify(payload, null, 2)], {
+        type: 'application/json'
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'dynaflow.json';
+      link.click();
+      URL.revokeObjectURL(url);
+    };
+
+    const handleValidate = () => {
+      const payload = buildFlowExport(state);
+      dispatch({ type: 'SET_VALIDATION', status: 'running', errors: [] });
+      fetch('/api/flow/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ flow: payload })
+      })
+        .then(async (response) => {
+          const result = await response.json();
+          if (!response.ok || !result.valid) {
+            dispatch({ type: 'SET_VALIDATION', status: 'invalid', errors: result.errors || [] });
+            dispatch({
+              type: 'ADD_TOAST',
+              toast: formatToast('Flow has validation issues.', 'error')
+            });
+          } else {
+            dispatch({ type: 'SET_VALIDATION', status: 'valid', errors: [] });
+            dispatch({
+              type: 'ADD_TOAST',
+              toast: formatToast('Flow looks good!', 'success')
+            });
+          }
+        })
+        .catch(() => {
+          dispatch({ type: 'SET_VALIDATION', status: 'invalid', errors: [] });
+          dispatch({
+            type: 'ADD_TOAST',
+            toast: formatToast('Validation failed. Check your server logs.', 'error')
+          });
+        });
+    };
+
+    const openInstallModal = () => {
+      dispatch({ type: 'TOGGLE_INSTALL_MODAL', visible: true });
+      setInstallError('');
+    };
+
+    const closeInstallModal = () => {
+      dispatch({ type: 'TOGGLE_INSTALL_MODAL', visible: false });
+      setInstallError('');
+    };
+
+    const handleInstallCatalog = (form) => {
+      setInstallPending(true);
+      setInstallError('');
+      const body = {
+        pip_url: form.pipUrl,
+        alias: form.alias || undefined,
+        module: form.module || undefined,
+        attribute: form.attribute || undefined
+      };
+      if (form.authType === 'basic') {
+        body.auth = {
+          type: 'basic',
+          username: form.username,
+          password: form.password
+        };
+      } else if (form.authType === 'token') {
+        body.auth = {
+          type: 'token',
+          token: form.token
+        };
+      }
+
+      fetch('/api/catalogs/install', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+        .then(async (response) => {
+          if (!response.ok) {
+            const data = await response.json().catch(() => ({}));
+            throw new Error(data.error || 'Installation failed');
+          }
+          closeInstallModal();
+          fetchCatalogs(dispatch);
+          dispatch({
+            type: 'ADD_TOAST',
+            toast: formatToast('Catalog installed successfully', 'success')
+          });
+        })
+        .catch((err) => {
+          setInstallError(err.message);
+        })
+        .finally(() => setInstallPending(false));
+    };
+
+    const handleRefreshCatalog = (alias) => {
+      fetch(`/api/catalogs/${encodeURIComponent(alias)}/refresh`, {
+        method: 'POST'
+      })
+        .then((response) => response.json())
+        .then(() => {
+          fetchCatalogs(dispatch);
+          dispatch({
+            type: 'ADD_TOAST',
+            toast: formatToast(`Catalog ${alias} refreshed`, 'success')
+          });
+        })
+        .catch(() =>
+          dispatch({
+            type: 'ADD_TOAST',
+            toast: formatToast(`Unable to refresh ${alias}`, 'error')
+          })
+        );
+    };
+
+    const handleRemoveCatalog = (alias) => {
+      fetch(`/api/catalogs/${encodeURIComponent(alias)}`, {
+        method: 'DELETE'
+      })
+        .then(() => {
+          fetchCatalogs(dispatch);
+          dispatch({
+            type: 'ADD_TOAST',
+            toast: formatToast(`Catalog ${alias} removed`, 'success')
+          });
+        })
+        .catch(() =>
+          dispatch({
+            type: 'ADD_TOAST',
+            toast: formatToast(`Unable to remove ${alias}`, 'error')
+          })
+        );
+    };
+
+    return h('div', { className: 'app-shell' }, [
+      h(AppHeader, {
+        flow,
+        onDownload: handleDownload,
+        onValidate: handleValidate,
+        onOpenInstall: openInstallModal,
+        validation: state.validation
+      }),
+      h('div', { className: 'app-body' }, [
+        h(Sidebar, {
+          catalogs: state.catalogs.items,
+          onRefreshCatalog: handleRefreshCatalog,
+          onRemoveCatalog: handleRemoveCatalog
+        }),
+        h(CanvasView, {
+          flow,
+          selection: state.selection,
+          canvasRef,
+          edges,
+          nodeRects,
+          onDropNode: handleDropNode,
+          onSelectNode: handleSelectNode,
+          onMoveNode: handleMoveNode,
+          onOpenFlow: handleNavigateFlow
+        }),
+        h(ConfigPanel, {
+          flows: state.flows,
+          currentFlow: flow,
+          selection: state.selection,
+          dispatch,
+          aggregatedFunctions: state.catalogs.aggregated,
+          onNavigateFlow: handleNavigateFlow
+        })
+      ]),
+      h(ValidationSummary, { validation: state.validation }),
+      state.showInstallModal
+        ? h(InstallCatalogModal, {
+            onClose: closeInstallModal,
+            onInstall: handleInstallCatalog,
+            pending: installPending,
+            error: installError
+          })
+        : null,
+      h(ToastContainer, { toasts: state.toasts })
+    ]);
+  }
+
+  render(h(App, null), document.getElementById('app'));
+})();

--- a/dynaflow/ui/static/app.js
+++ b/dynaflow/ui/static/app.js
@@ -310,6 +310,7 @@
       case "TOGGLE_INSTALL_MODAL":
         return { ...state, showInstallModal: action.visible };
       case "SET_SELECTION":
+        console.log('🎯 SET_SELECTION action:', action.selection);
         return { ...state, selection: action.selection };
       case "CLEAR_SELECTION":
         return { ...state, selection: null };
@@ -328,8 +329,10 @@
           validation: { status: action.status, errors: action.errors || [] }
         };
       case "ADD_NODE": {
+        console.log('🔧 ADD_NODE action:', action);
         const flow = state.flows[action.flowId];
         if (!flow) {
+          console.error('Flow no encontrado:', action.flowId);
           return state;
         }
         return produce(state, (draft) => {
@@ -337,6 +340,18 @@
           const { node, flows: newFlows } = createNodeTemplate(action.nodeType, baseFlow, {
             position: action.position
           });
+          console.log('✅ Nodo creado:', node);
+          
+          // Auto-conectar al nodo anterior si existe
+          const lastNodeId = baseFlow.order[baseFlow.order.length - 1];
+          if (lastNodeId && baseFlow.nodes[lastNodeId]) {
+            const lastNode = baseFlow.nodes[lastNodeId];
+            if (!lastNode.transitions.next && !lastNode.transitions.end) {
+              console.log('🔗 Conectando automáticamente:', lastNodeId, '->', node.id);
+              lastNode.transitions.next = node.id;
+            }
+          }
+          
           baseFlow.nodes[node.id] = node;
           baseFlow.order.push(node.id);
           if (!baseFlow.startNodeId) {
@@ -350,8 +365,10 @@
         });
       }
       case "UPDATE_NODE_POSITION": {
+        console.log('🔄 UPDATE_NODE_POSITION action:', action);
         const flow = state.flows[action.flowId];
         if (!flow || !flow.nodes[action.nodeId]) {
+          console.error('Flow o nodo no encontrado:', { flowId: action.flowId, nodeId: action.nodeId });
           return state;
         }
         const node = flow.nodes[action.nodeId];
@@ -359,8 +376,10 @@
           node.position.x === action.position.x &&
           node.position.y === action.position.y
         ) {
+          console.log('Posición igual, no hay cambios');
           return state;
         }
+        console.log('✅ Actualizando posición del nodo:', { from: node.position, to: action.position });
         return produce(state, (draft) => {
           const updatedFlow = cloneFlow(flow);
           const updatedNode = cloneNode(updatedFlow.nodes[action.nodeId]);
@@ -384,6 +403,7 @@
             node.comment = action.changes.comment;
           }
           if (action.changes.transitions) {
+            console.log('🔗 Actualizando transiciones:', action.changes.transitions);
             node.transitions = { ...node.transitions, ...action.changes.transitions };
           }
           if (action.changes.config) {
@@ -393,6 +413,13 @@
           draft.flows[action.flowId] = updatedFlow;
           if (action.changes.start === true) {
             updatedFlow.startNodeId = node.id;
+          }
+          // Incrementar revision para forzar re-render de conexiones
+          draft.revision = (state.revision || 0) + 1;
+          
+          // Actualizar selection si es el nodo actual para refrescar ConfigPanel
+          if (state.selection && state.selection.nodeId === action.nodeId) {
+            draft.selection = { ...state.selection, nodeId: action.nodeId };
           }
         });
       }
@@ -774,7 +801,7 @@
   function useCatalogs(dispatch) {
     useEffect(() => {
       fetchCatalogs(dispatch);
-    }, [dispatch]);
+    }, []); // Solo ejecutar una vez al montar el componente
   }
 
   function fetchCatalogs(dispatch) {
@@ -801,10 +828,13 @@
   function computeEdges(flow) {
     if (!flow) return [];
     const edges = [];
+    console.log('🔗 Computando edges para flow:', flow.id, 'con nodos:', Object.keys(flow.nodes));
+    
     flow.order.forEach((nodeId) => {
       const node = flow.nodes[nodeId];
       if (!node) return;
       if (node.transitions.next) {
+        console.log('➡️ Creando edge:', nodeId, '->', node.transitions.next);
         edges.push({
           id: `next-${nodeId}`,
           from: nodeId,
@@ -815,6 +845,7 @@
       if (node.type === "Choice") {
         (node.config.choices || []).forEach((choice, index) => {
           if (choice.next) {
+            console.log('🔀 Creando choice edge:', nodeId, '->', choice.next);
             edges.push({
               id: `choice-${nodeId}-${index}`,
               from: nodeId,
@@ -824,6 +855,7 @@
           }
         });
         if (node.transitions.default) {
+          console.log('🔄 Creando default edge:', nodeId, '->', node.transitions.default);
           edges.push({
             id: `choice-default-${nodeId}`,
             from: nodeId,
@@ -833,6 +865,8 @@
         }
       }
     });
+    
+    console.log('🔗 Total edges creados:', edges.length, edges);
     return edges;
   }
 
@@ -855,11 +889,43 @@
     );
   }
 
-  function AppHeader({ flow, onDownload, onValidate, onOpenInstall, validation }) {
+  function AppHeader({ flow, flows, onDownload, onValidate, onOpenInstall, onNavigateFlow, validation }) {
+    // Construir breadcrumb desde el flow actual hacia arriba
+    const buildBreadcrumb = () => {
+      if (!flow) return [];
+      
+      const breadcrumb = [];
+      let currentFlow = flow;
+      
+      while (currentFlow) {
+        breadcrumb.unshift(currentFlow);
+        
+        if (currentFlow.parent && flows[currentFlow.parent.flowId]) {
+          currentFlow = flows[currentFlow.parent.flowId];
+        } else {
+          break;
+        }
+      }
+      
+      return breadcrumb;
+    };
+    
+    const breadcrumb = buildBreadcrumb();
+    
     return h('header', { className: 'app-header' }, [
       h('div', { className: 'title-block' }, [
         h('h1', { className: 'title' }, 'DynaFlow Studio'),
-        h('span', { className: 'tagline' }, flow ? flow.label : 'Workflow')
+        breadcrumb.length > 1 ? h('div', { className: 'breadcrumb' }, 
+          breadcrumb.map((breadFlow, index) => 
+            h('span', { key: breadFlow.id, className: 'breadcrumb-item' }, [
+              index > 0 ? h('span', { className: 'breadcrumb-separator' }, ' / ') : null,
+              h('button', {
+                className: breadFlow.id === flow.id ? 'breadcrumb-current' : 'breadcrumb-link',
+                onClick: () => breadFlow.id !== flow.id && onNavigateFlow(breadFlow.id)
+              }, breadFlow.label)
+            ])
+          )
+        ) : h('span', { className: 'tagline' }, flow ? flow.label : 'Workflow')
       ]),
       h('div', { className: 'header-actions' }, [
         h(
@@ -883,12 +949,42 @@
             onClick: onDownload
           },
           'Download JSON'
+        ),
+        h(
+          'button',
+          {
+            onClick: () => {
+              console.log('🧪 DEBUG STATE:', window.debugState);
+              console.log('🧪 CURRENT FLOW:', window.debugState?.flows[window.debugState?.currentFlowId]);
+            }
+          },
+          'Debug State'
+        ),
+        h(
+          'button',
+          {
+            onClick: () => {
+              const currentFlow = window.debugState?.flows[window.debugState?.currentFlowId];
+              if (currentFlow && currentFlow.order.length >= 2) {
+                const firstNode = currentFlow.order[0];
+                const secondNode = currentFlow.order[1];
+                console.log('🧪 TEST: Conectando manualmente', firstNode, '->', secondNode);
+                window.debugDispatch({
+                  type: 'UPDATE_NODE',
+                  flowId: currentFlow.id,
+                  nodeId: firstNode,
+                  changes: { transitions: { next: secondNode } }
+                });
+              }
+            }
+          },
+          'Test Connect'
         )
       ])
     ]);
   }
 
-  function Sidebar({ catalogs, onRefreshCatalog, onRemoveCatalog }) {
+  function Sidebar({ catalogs, onRefreshCatalog, onRemoveCatalog, onAddNode }) {
     return h('aside', { className: 'sidebar' }, [
       h('div', { className: 'section-header' }, 'Function catalogs'),
       h('div', { className: 'sidebar-content' }, [
@@ -899,7 +995,8 @@
         }),
         h('div', { className: 'palette' }, [
           h('div', { className: 'section-header' }, 'Node palette'),
-          h(NodePalette, null)
+          h('small', { className: 'subtitle', style: { marginBottom: '8px', display: 'block' } }, 'Haz clic en el botón + para agregar nodos'),
+          h(NodePalette, { onAddNode })
         ])
       ])
     ]);
@@ -943,25 +1040,62 @@
     );
   }
 
-  function NodePalette() {
+  function NodePalette({ onAddNode }) {
     return h(
       'div',
       null,
       NODE_TYPES.map((node) =>
-        h(
-          'div',
-          {
-            className: 'node-type',
-            key: node.id,
-            draggable: true,
-            onDragStart: (event) => {
-              event.dataTransfer.effectAllowed = 'copy';
-              event.dataTransfer.setData('application/x-node-type', node.id);
-            }
-          },
+          h(
+            'div',
+            {
+              className: 'node-type',
+              key: node.id,
+              draggable: true,
+              onClick: (event) => {
+                console.log('🔍 Click simple en nodo:', node.id);
+                if (event.detail === 2) { // Detectar doble clic
+                  console.log('📋 DOBLE CLIC detectado en nodo de paleta:', node.id);
+                  console.log('onAddNode disponible:', !!onAddNode);
+                  if (onAddNode) {
+                    // Agregar en una posición centrada y un poco aleatoria
+                    const position = {
+                      x: 200 + Math.random() * 300,
+                      y: 150 + Math.random() * 200
+                    };
+                    console.log('Agregando nodo en posición:', position);
+                    onAddNode(node.id, position);
+                  } else {
+                    console.error('onAddNode no está disponible');
+                  }
+                }
+              },
+              onDragStart: (event) => {
+                event.dataTransfer.effectAllowed = 'copy';
+                event.dataTransfer.setData('application/x-node-type', node.id);
+              }
+            },
           [
-            h('span', null, node.label),
-            h('small', { className: 'subtitle' }, node.description)
+            h('div', { className: 'node-info' }, [
+              h('span', null, node.label),
+              h('small', { className: 'subtitle' }, node.description)
+            ]),
+            h('button', {
+              className: 'add-node-btn',
+              onClick: (event) => {
+                event.stopPropagation();
+                console.log('➕ Botón + presionado para nodo:', node.id);
+                if (onAddNode) {
+                  const position = {
+                    x: 200 + Math.random() * 300,
+                    y: 150 + Math.random() * 200
+                  };
+                  console.log('Agregando nodo desde botón en posición:', position);
+                  onAddNode(node.id, position);
+                } else {
+                  console.error('onAddNode no está disponible desde botón');
+                }
+              }
+            }, '+')
           ]
         )
       )
@@ -1027,33 +1161,59 @@
       }
     }, [node, onOpenFlow]);
 
-    useEffect(() => {
-      const element = ref.current;
-      if (!element) return;
-      const handlePointerDown = (event) => {
-        event.preventDefault();
-        onSelect(node.id);
-        const startX = event.clientX;
-        const startY = event.clientY;
-        const initial = { ...node.position };
-        const move = (moveEvent) => {
-          moveEvent.preventDefault();
+    // Manejadores simples como propiedades del elemento
+    const handleClick = useCallback((event) => {
+      event.stopPropagation();
+      console.log('🖱️ CLICK SIMPLE en nodo:', node.id);
+      onSelect(node.id);
+    }, [node.id, onSelect]);
+
+    const handleMouseDown = useCallback((event) => {
+      if (event.button !== 0) return;
+      
+      console.log('🖱️ MOUSEDOWN en nodo:', node.id);
+      event.preventDefault();
+      
+      let isDragging = false;
+      const startX = event.clientX;
+      const startY = event.clientY;
+      const initialPosition = { ...node.position };
+      
+      const handleMouseMove = (moveEvent) => {
+        const deltaX = Math.abs(moveEvent.clientX - startX);
+        const deltaY = Math.abs(moveEvent.clientY - startY);
+        
+        if (!isDragging && (deltaX > 5 || deltaY > 5)) {
+          isDragging = true;
+          console.log('🚀 INICIANDO ARRASTRE del nodo:', node.id);
+          document.body.style.cursor = 'grabbing';
+        }
+        
+        if (isDragging) {
           const dx = moveEvent.clientX - startX;
           const dy = moveEvent.clientY - startY;
-          onMove(node.id, { x: initial.x + dx, y: initial.y + dy });
-        };
-        const stop = () => {
-          window.removeEventListener('pointermove', move);
-          window.removeEventListener('pointerup', stop);
-        };
-        window.addEventListener('pointermove', move);
-        window.addEventListener('pointerup', stop);
+          const newPosition = {
+            x: initialPosition.x + dx,
+            y: initialPosition.y + dy
+          };
+          console.log('📍 MOVIENDO nodo:', node.id, 'a posición:', newPosition);
+          onMove(node.id, newPosition);
+        }
       };
-      element.addEventListener('pointerdown', handlePointerDown);
-      return () => {
-        element.removeEventListener('pointerdown', handlePointerDown);
+      
+      const handleMouseUp = () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+        document.body.style.cursor = '';
+        
+        if (isDragging) {
+          console.log('🛑 FIN ARRASTRE del nodo:', node.id);
+        }
       };
-    }, [node.id, node.position.x, node.position.y, onMove, onSelect]);
+      
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    }, [node.id, node.position, onMove]);
 
     const className = `${getNodeClass(node.type)}${selected ? ' selected' : ''}`;
 
@@ -1067,6 +1227,8 @@
           left: `${node.position.x}px`,
           top: `${node.position.y}px`
         },
+        onClick: handleClick,
+        onMouseDown: handleMouseDown,
         onDoubleClick: handleDoubleClick
       },
       [
@@ -1090,22 +1252,56 @@
   }
 
   function LinkLayer({ edges, rects }) {
-    if (!edges.length) return null;
+    console.log('🔗 LinkLayer render:', { 
+      edgesCount: edges.length, 
+      edges: edges,
+      rectsKeys: Object.keys(rects)
+    });
+    
+    if (!edges.length) {
+      console.log('❌ No hay edges para renderizar');
+      return null;
+    }
+    
     return h(
       'svg',
-      { className: 'link-canvas' },
+      { 
+        className: 'link-canvas',
+        width: '100%',
+        height: '100%',
+        style: { position: 'absolute', top: 0, left: 0, zIndex: 10 }
+      },
       edges.map((edge) => {
         const source = rects[edge.from];
         const target = rects[edge.to];
+        console.log('🎯 Procesando edge:', edge.id, { 
+          from: edge.from, 
+          to: edge.to, 
+          hasSource: !!source, 
+          hasTarget: !!target 
+        });
+        
         if (!source || !target) {
+          console.log('❌ Edge sin rects:', edge.id, { source, target });
           return null;
         }
         const startX = source.left + source.width;
         const startY = source.top + source.height / 2;
         const endX = target.left;
         const endY = target.top + target.height / 2;
-        const midX = startX + (endX - startX) * 0.5;
-        const path = `M ${startX} ${startY} C ${midX} ${startY}, ${midX} ${endY}, ${endX} ${endY}`;
+        
+        // Path simple y directo - línea recta con una pequeña curva
+        const midX = startX + (endX - startX) * 0.6;
+        const path = `M ${startX} ${startY} Q ${midX} ${startY} ${endX - 10} ${endY}`;
+        
+        console.log('🎨 DIBUJANDO flecha simple:', {
+          edge: edge.id,
+          coords: `${startX},${startY} -> ${endX},${endY}`,
+          path,
+          sourceSize: `${source.width}x${source.height}`,
+          targetSize: `${target.width}x${target.height}`
+        });
+        
         return h(
           'g',
           { key: edge.id },
@@ -1113,14 +1309,15 @@
             h('path', {
               d: path,
               fill: 'none',
-              stroke: 'rgba(148,163,184,0.35)',
-              'stroke-width': 2
+              stroke: '#38bdf8',
+              strokeWidth: 4,
+              opacity: 1
             }),
             h('circle', {
-              cx: endX,
+              cx: endX - 10,
               cy: endY,
-              r: 4,
-              fill: 'rgba(56,189,248,0.85)'
+              r: 6,
+              fill: '#38bdf8'
             }),
             edge.label
               ? h(
@@ -1147,23 +1344,33 @@
     aggregatedFunctions,
     onNavigateFlow
   }) {
-    const node = selection && currentFlow ? currentFlow.nodes[selection.nodeId] : null;
+    // SIEMPRE obtener el nodo más actualizado desde flows
+    const actualFlow = selection ? flows[selection.flowId] : currentFlow;
+    const node = selection && actualFlow ? actualFlow.nodes[selection.nodeId] : null;
+    
+    console.log('🔧 ConfigPanel render:', {
+      selectionNodeId: selection?.nodeId,
+      flowId: selection?.flowId,
+      hasActualFlow: !!actualFlow,
+      hasNode: !!node,
+      nodeTransitions: node?.transitions
+    });
     return h('aside', { className: 'config-panel' }, [
       h('div', { className: 'section-header' }, 'Configuration'),
       h(
         'div',
         { className: 'config-content' },
-        node && currentFlow
+        node && actualFlow
           ? [
-              h(FlowBreadcrumb, { flow: currentFlow, flows, onNavigate: onNavigateFlow }),
+              h(FlowBreadcrumb, { flow: actualFlow, flows, onNavigate: onNavigateFlow }),
               h(NodeGeneralSettings, {
-                flow: currentFlow,
+                flow: actualFlow,
                 node,
                 dispatch
               }),
               renderNodeEditor({
                 node,
-                flow: currentFlow,
+                flow: actualFlow,
                 dispatch,
                 aggregatedFunctions,
                 flows,
@@ -1203,19 +1410,83 @@
     return ['Task', 'Pass', 'Wait', 'Map', 'Parallel'].includes(type);
   }
 
+  function NextStateSelect({ node, nextOptions, onChange }) {
+    const [localValue, setLocalValue] = useState(node.transitions.next || '');
+    
+    // Sincronizar valor local cuando cambia el nodo
+    useEffect(() => {
+      const expectedValue = node.transitions.next || '';
+      console.log('🔄 NextStateSelect sync:', { 
+        localValue, 
+        expectedValue, 
+        nodeId: node.id 
+      });
+      setLocalValue(expectedValue);
+    }, [node.transitions.next, node.id]);
+    
+    const handleChange = (event) => {
+      const newValue = event.target.value;
+      console.log('🔄 NextStateSelect handleChange:', { from: localValue, to: newValue });
+      setLocalValue(newValue);
+      onChange(event);
+    };
+    
+    return h(
+      'select',
+      {
+        value: localValue,
+        disabled: node.transitions.end,
+        onChange: handleChange
+      },
+      [
+        h('option', { value: '' }, '— None —'),
+        ...nextOptions.map((option) =>
+          h('option', { key: option.id, value: option.id }, option.label)
+        )
+      ]
+    );
+  }
+
   function NodeGeneralSettings({ flow, node, dispatch }) {
+    const selectRef = useRef(null);
+    
+    console.log('🔧 NodeGeneralSettings render:', {
+      nodeId: node.id,
+      nodeName: node.name,
+      currentNext: node.transitions.next,
+      allTransitions: node.transitions
+    });
+    
     const nextOptions = flow.order
       .filter((id) => id !== node.id)
       .map((id) => ({ id, label: flow.nodes[id].name }));
+      
+    console.log('🔧 NextOptions disponibles:', nextOptions);
+    
+    // Forzar sincronización del select cuando cambia node.transitions.next
+    useEffect(() => {
+      if (selectRef.current) {
+        const expectedValue = node.transitions.next || '';
+        if (selectRef.current.value !== expectedValue) {
+          console.log('🔧 Sincronizando select:', selectRef.current.value, '->', expectedValue);
+          selectRef.current.value = expectedValue;
+        }
+      }
+    }, [node.transitions.next]);
 
-    const handleNameChange = (event) => {
-      dispatch({
-        type: 'UPDATE_NODE',
-        flowId: flow.id,
-        nodeId: node.id,
-        changes: { name: event.target.value }
-      });
-    };
+    const handleNameChange = useCallback((event) => {
+      const value = event.target.value;
+      // Usar timeout para evitar updates constantes que causan pérdida de foco
+      clearTimeout(handleNameChange.timeoutId);
+      handleNameChange.timeoutId = setTimeout(() => {
+        dispatch({
+          type: 'UPDATE_NODE',
+          flowId: flow.id,
+          nodeId: node.id,
+          changes: { name: value }
+        });
+      }, 300);
+    }, [dispatch, flow.id, node.id]);
 
     const handleCommentChange = (event) => {
       dispatch({
@@ -1241,11 +1512,17 @@
     };
 
     const handleNextChange = (event) => {
+      const nextValue = event.target.value || null;
+      console.log('🔄 handleNextChange:', { 
+        from: node.transitions.next, 
+        to: nextValue, 
+        nodeId: node.id 
+      });
       dispatch({
         type: 'UPDATE_NODE',
         flowId: flow.id,
         nodeId: node.id,
-        changes: { transitions: { next: event.target.value || null } }
+        changes: { transitions: { next: nextValue } }
       });
     };
 
@@ -1264,7 +1541,7 @@
         h('label', null, 'State name'),
         h('input', {
           value: node.name,
-          onInput: handleNameChange
+          onChange: handleNameChange
         })
       ]),
       h('div', { className: 'form-field' }, [
@@ -1296,20 +1573,11 @@
       supportsNextTransition(node.type)
         ? h('div', { className: 'form-field' }, [
             h('label', null, 'Next state'),
-            h(
-              'select',
-              {
-                value: node.transitions.next || '',
-                disabled: node.transitions.end,
-                onChange: handleNextChange
-              },
-              [
-                h('option', { value: '' }, '— None —'),
-                ...nextOptions.map((option) =>
-                  h('option', { key: option.id, value: option.id }, option.label)
-                )
-              ]
-            )
+            h(NextStateSelect, {
+              node,
+              nextOptions,
+              onChange: handleNextChange
+            })
           ])
         : null,
       h('div', { className: 'switch-row' }, [
@@ -2237,33 +2505,58 @@
     const [installError, setInstallError] = useState('');
     const canvasRef = useRef(null);
     const flow = state.flows[state.currentFlowId];
+    
+    // Exponer estado para debugging
+    window.debugState = state;
+    window.debugDispatch = dispatch;
 
     useCatalogs(dispatch);
     useToasts(state, dispatch);
 
     useEffect(() => {
-      const container = canvasRef.current;
-      if (!container) return;
-      const parentRect = container.getBoundingClientRect();
-      const rects = {};
-      container.querySelectorAll('[data-node-id]').forEach((element) => {
-        const id = element.getAttribute('data-node-id');
-        const bounds = element.getBoundingClientRect();
-        rects[id] = {
-          left: bounds.left - parentRect.left,
-          top: bounds.top - parentRect.top,
-          width: bounds.width,
-          height: bounds.height
-        };
-      });
-      setNodeRects(rects);
-    }, [state.currentFlowId, state.revision, flow ? flow.order.length : 0]);
+      if (!flow || !canvasRef.current) return;
+      
+      // Usar requestAnimationFrame para asegurar que el layout esté completo
+      const captureRects = () => {
+        const container = canvasRef.current;
+        if (!container) return;
+        
+        const rects = {};
+        const containerRect = container.getBoundingClientRect();
+        
+        // Buscar nodos directamente en el container
+        flow.order.forEach((nodeId) => {
+          const element = container.querySelector(`[data-node-id="${nodeId}"]`);
+          if (element) {
+            const rect = element.getBoundingClientRect();
+            rects[nodeId] = {
+              left: rect.left - containerRect.left,
+              top: rect.top - containerRect.top,
+              width: rect.width,
+              height: rect.height
+            };
+            console.log('📐 Rect capturado para', nodeId, ':', rects[nodeId]);
+          } else {
+            console.log('❌ No se encontró elemento para', nodeId);
+          }
+        });
+        
+        console.log('📐 RequestAnimationFrame: nodeRects capturados:', Object.keys(rects).length);
+        setNodeRects(rects);
+      };
+      
+      requestAnimationFrame(captureRects);
+    }, [flow, state.revision]);
 
     const edges = useMemo(() => computeEdges(flow), [flow, state.revision]);
 
     const handleDropNode = useCallback(
       (type, position) => {
-        if (!flow) return;
+        console.log('🎯 handleDropNode llamado:', { type, position, flowId: flow?.id });
+        if (!flow) {
+          console.error('No hay flow disponible');
+          return;
+        }
         dispatch({ type: 'ADD_NODE', flowId: flow.id, nodeType: type, position });
       },
       [dispatch, flow]
@@ -2271,7 +2564,11 @@
 
     const handleSelectNode = useCallback(
       (nodeId) => {
-        if (!flow) return;
+        console.log('🎯 handleSelectNode llamado:', { nodeId, flowId: flow?.id });
+        if (!flow) {
+          console.error('No hay flow disponible para seleccionar nodo');
+          return;
+        }
         dispatch({ type: 'SET_SELECTION', selection: { flowId: flow.id, nodeId } });
       },
       [dispatch, flow]
@@ -2279,7 +2576,11 @@
 
     const handleMoveNode = useCallback(
       (nodeId, position) => {
-        if (!flow) return;
+        console.log('🔄 handleMoveNode llamado:', { nodeId, position, flowId: flow?.id });
+        if (!flow) {
+          console.error('No hay flow disponible para mover nodo');
+          return;
+        }
         dispatch({ type: 'UPDATE_NODE_POSITION', flowId: flow.id, nodeId, position });
       },
       [dispatch, flow]
@@ -2435,16 +2736,19 @@
     return h('div', { className: 'app-shell' }, [
       h(AppHeader, {
         flow,
+        flows: state.flows,
         onDownload: handleDownload,
         onValidate: handleValidate,
         onOpenInstall: openInstallModal,
+        onNavigateFlow: handleNavigateFlow,
         validation: state.validation
       }),
       h('div', { className: 'app-body' }, [
         h(Sidebar, {
           catalogs: state.catalogs.items,
           onRefreshCatalog: handleRefreshCatalog,
-          onRemoveCatalog: handleRemoveCatalog
+          onRemoveCatalog: handleRemoveCatalog,
+          onAddNode: handleDropNode
         }),
         h(CanvasView, {
           flow,

--- a/dynaflow/ui/static/index.html
+++ b/dynaflow/ui/static/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DynaFlow Studio</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="app">
+      <div class="loading">
+        <div class="spinner"></div>
+        <p>Loading DynaFlow Studio…</p>
+      </div>
+    </div>
+    <script src="minireact.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/dynaflow/ui/static/minireact.js
+++ b/dynaflow/ui/static/minireact.js
@@ -1,0 +1,332 @@
+(function (global) {
+  const TEXT_ELEMENT = "__text__";
+  const Fragment = Symbol("Fragment");
+
+  class ComponentInstance {
+    constructor(type, key) {
+      this.type = type;
+      this.key = key;
+      this.hooks = [];
+      this.hookIndex = 0;
+      this.pendingEffects = [];
+    }
+  }
+
+  const instances = new Map();
+  let currentInstance = null;
+  let rootElement = null;
+  let rootContainer = null;
+  let renderScheduled = false;
+  let visitedInstances = new Set();
+  let queuedEffects = [];
+
+  function createElement(type, props, ...children) {
+    const normalized = [];
+    const rawChildren = (props && props.children) || [];
+    const list = children.length ? children : Array.isArray(rawChildren) ? rawChildren : [rawChildren];
+    for (const child of list.flat()) {
+      if (child === false || child === true || child == null) {
+        continue;
+      }
+      if (typeof child === "object") {
+        normalized.push(child);
+      } else {
+        normalized.push(createTextElement(child));
+      }
+    }
+    const cleanProps = Object.assign({}, props || {});
+    delete cleanProps.children;
+    return {
+      type: type === Fragment ? Fragment : type,
+      props: Object.assign(cleanProps, { children: normalized })
+    };
+  }
+
+  function createTextElement(value) {
+    return {
+      type: TEXT_ELEMENT,
+      props: { nodeValue: value == null ? "" : String(value), children: [] }
+    };
+  }
+
+  function render(element, container) {
+    rootElement = element;
+    rootContainer = container;
+    scheduleRender();
+  }
+
+  function scheduleRender() {
+    if (renderScheduled) {
+      return;
+    }
+    renderScheduled = true;
+    queueMicrotask(() => {
+      renderScheduled = false;
+      performRender();
+    });
+  }
+
+  function performRender() {
+    if (!rootContainer || !rootElement) {
+      return;
+    }
+    visitedInstances = new Set();
+    queuedEffects = [];
+    while (rootContainer.firstChild) {
+      rootContainer.removeChild(rootContainer.firstChild);
+    }
+    renderNode(rootElement, rootContainer, "root");
+    cleanupUnusedInstances();
+    runQueuedEffects();
+  }
+
+  function renderNode(element, container, path) {
+    if (element == null) {
+      return;
+    }
+    if (Array.isArray(element)) {
+      element.forEach((child, index) => renderNode(child, container, path + "." + index));
+      return;
+    }
+
+    const { type, props } = element;
+    if (type === TEXT_ELEMENT) {
+      const text = document.createTextNode(props.nodeValue || "");
+      container.appendChild(text);
+      return;
+    }
+
+    if (type === Fragment) {
+      const fragmentChildren = props.children || [];
+      fragmentChildren.forEach((child, index) => renderNode(child, container, path + "." + index));
+      return;
+    }
+
+    if (typeof type === "function") {
+      const key = buildInstanceKey(path, type, props);
+      let instance = instances.get(key);
+      if (!instance || instance.type !== type) {
+        if (instance) {
+          cleanupInstance(instance);
+        }
+        instance = new ComponentInstance(type, key);
+        instances.set(key, instance);
+      }
+      visitedInstances.add(key);
+      const prevInstance = currentInstance;
+      currentInstance = instance;
+      instance.hookIndex = 0;
+      instance.pendingEffects = [];
+      const output = type(Object.assign({}, props));
+      renderNode(output, container, key);
+      queuedEffects.push({ key, instance, effects: instance.pendingEffects.slice() });
+      currentInstance = prevInstance;
+      return;
+    }
+
+    const dom = document.createElement(type);
+    visitedInstances.add(path);
+    applyProps(dom, {}, props || {});
+    const children = props && props.children ? props.children : [];
+    children.forEach((child, index) => renderNode(child, dom, path + ":" + index));
+    container.appendChild(dom);
+  }
+
+  function applyProps(dom, prevProps, nextProps) {
+    Object.keys(prevProps).forEach((name) => {
+      if (name === "children") {
+        return;
+      }
+      if (!(name in nextProps)) {
+        setProp(dom, name, null);
+      }
+    });
+
+    Object.keys(nextProps).forEach((name) => {
+      if (name === "children") {
+        return;
+      }
+      setProp(dom, name, nextProps[name]);
+    });
+  }
+
+  function setProp(dom, name, value) {
+    if (name === "style" && value && typeof value === "object") {
+      Object.assign(dom.style, value);
+      return;
+    }
+    if (name === "className") {
+      dom.setAttribute("class", value || "");
+      return;
+    }
+    if (name === "ref" && typeof value === "function") {
+      value(dom);
+      return;
+    }
+    if (name.startsWith("on") && typeof value === "function") {
+      const eventName = name.slice(2).toLowerCase();
+      dom.addEventListener(eventName, value);
+      return;
+    }
+    if (value === false || value === null || value === undefined) {
+      dom.removeAttribute(name);
+      return;
+    }
+    dom.setAttribute(name, value === true ? "" : value);
+  }
+
+  function buildInstanceKey(path, type, props) {
+    const name = type.displayName || type.name || "component";
+    const key = props && props.key ? String(props.key) : "";
+    return `${path}:${name}:${key}`;
+  }
+
+  function cleanupUnusedInstances() {
+    const unused = [];
+    instances.forEach((instance, key) => {
+      if (!visitedInstances.has(key)) {
+        unused.push(key);
+        cleanupInstance(instance);
+      }
+    });
+    unused.forEach((key) => instances.delete(key));
+  }
+
+  function cleanupInstance(instance) {
+    instance.hooks.forEach((hook) => {
+      if (hook && hook.kind === "effect" && typeof hook.cleanup === "function") {
+        try {
+          hook.cleanup();
+        } catch (err) {
+          console.warn("Error during effect cleanup", err);
+        }
+        hook.cleanup = undefined;
+      }
+    });
+  }
+
+  function runQueuedEffects() {
+    queuedEffects.forEach(({ instance, effects }) => {
+      effects.forEach((entry) => {
+        const hook = instance.hooks[entry.index];
+        if (!hook || hook.kind !== "effect") {
+          return;
+        }
+        const deps = hook.nextDeps;
+        const changed = depsChanged(hook.prevDeps, deps);
+        if (!changed) {
+          return;
+        }
+        if (typeof hook.cleanup === "function") {
+          try {
+            hook.cleanup();
+          } catch (err) {
+            console.warn("Error during effect cleanup", err);
+          }
+        }
+        try {
+          const cleanup = hook.effect();
+          hook.cleanup = typeof cleanup === "function" ? cleanup : undefined;
+          hook.prevDeps = deps ? deps.slice() : deps;
+        } catch (err) {
+          console.error("Effect execution error", err);
+        }
+      });
+    });
+  }
+
+  function depsChanged(prev, next) {
+    if (!prev || !next) {
+      return true;
+    }
+    if (prev.length !== next.length) {
+      return true;
+    }
+    for (let i = 0; i < prev.length; i += 1) {
+      if (!Object.is(prev[i], next[i])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function prepareHook(kind) {
+    if (!currentInstance) {
+      throw new Error("Hooks can only be used inside function components");
+    }
+    const index = currentInstance.hookIndex++;
+    let hook = currentInstance.hooks[index];
+    if (!hook || hook.kind !== kind) {
+      hook = { kind };
+      currentInstance.hooks[index] = hook;
+    }
+    hook.index = index;
+    return hook;
+  }
+
+  function useState(initialValue) {
+    const hook = prepareHook("state");
+    if (!Object.prototype.hasOwnProperty.call(hook, "value")) {
+      hook.value = typeof initialValue === "function" ? initialValue() : initialValue;
+    }
+    const setState = (next) => {
+      const value = typeof next === "function" ? next(hook.value) : next;
+      if (!Object.is(value, hook.value)) {
+        hook.value = value;
+        scheduleRender();
+      }
+    };
+    return [hook.value, setState];
+  }
+
+  function useReducer(reducer, initialArg, init) {
+    const [state, setState] = useState(() => (init ? init(initialArg) : initialArg));
+    const dispatch = (action) => {
+      setState((prev) => reducer(prev, action));
+    };
+    return [state, dispatch];
+  }
+
+  function useMemo(factory, deps) {
+    const hook = prepareHook("memo");
+    if (!hook.hasOwnProperty("value") || depsChanged(hook.deps, deps)) {
+      hook.value = factory();
+      hook.deps = deps ? deps.slice() : deps;
+    }
+    return hook.value;
+  }
+
+  function useCallback(callback, deps) {
+    return useMemo(() => callback, deps);
+  }
+
+  function useRef(initialValue) {
+    const hook = prepareHook("ref");
+    if (!hook.hasOwnProperty("current")) {
+      hook.current = { current: initialValue };
+    }
+    return hook.current;
+  }
+
+  function useEffect(effect, deps) {
+    const hook = prepareHook("effect");
+    hook.effect = effect;
+    hook.nextDeps = deps ? deps.slice() : deps;
+    currentInstance.pendingEffects.push({ index: hook.index });
+  }
+
+  const MiniReact = {
+    createElement,
+    Fragment,
+    render,
+    useState,
+    useReducer,
+    useMemo,
+    useCallback,
+    useEffect,
+    useRef,
+    h: createElement
+  };
+
+  global.MiniReact = MiniReact;
+})(window);

--- a/dynaflow/ui/static/styles.css
+++ b/dynaflow/ui/static/styles.css
@@ -1,0 +1,802 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --bg-alt: #111827;
+  --bg-panel: rgba(15, 23, 42, 0.9);
+  --canvas: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 30%, rgba(129, 140, 248, 0.18), transparent 55%),
+    linear-gradient(145deg, rgba(15, 23, 42, 0.94), rgba(17, 24, 39, 0.9));
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.15);
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --danger: #f87171;
+  --success: #34d399;
+  --warning: #facc15;
+  --radius-lg: 18px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#app {
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+}
+
+.loading {
+  margin: auto;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  margin: 0 auto 12px;
+  border: 4px solid rgba(148, 163, 184, 0.2);
+  border-top-color: var(--accent);
+  animation: spin 1.2s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.app-shell {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(22px);
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 32px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.title-block {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.app-header h1 {
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text);
+  margin: 0;
+}
+
+.tagline {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-left: 14px;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.header-actions button {
+  appearance: none;
+  border: none;
+  padding: 10px 18px;
+  border-radius: var(--radius-sm);
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.header-actions button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0f172a;
+}
+
+.header-actions button:hover {
+  transform: translateY(-1px);
+  background: rgba(56, 189, 248, 0.25);
+}
+
+.header-actions button.primary:hover {
+  background: linear-gradient(135deg, var(--accent-strong), #38bdf8);
+}
+
+.app-body {
+  display: grid;
+  grid-template-columns: 320px 1fr 360px;
+  flex: 1;
+  overflow: hidden;
+}
+
+.sidebar,
+.config-panel {
+  background: rgba(15, 23, 42, 0.78);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.config-panel {
+  border-left: 1px solid var(--border);
+  border-right: none;
+}
+
+.sidebar .section-header,
+.config-panel .section-header {
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--text-muted);
+}
+
+.sidebar-content,
+.config-content {
+  padding: 22px;
+  overflow-y: auto;
+}
+
+.sidebar-content::-webkit-scrollbar,
+.config-content::-webkit-scrollbar {
+  width: 8px;
+}
+
+.sidebar-content::-webkit-scrollbar-thumb,
+.config-content::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+}
+
+.catalogs {
+  margin-bottom: 28px;
+}
+
+.catalog-card {
+  background: rgba(30, 41, 59, 0.72);
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.4);
+  margin-bottom: 12px;
+  position: relative;
+}
+
+.catalog-card strong {
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.catalog-card .meta {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-top: 6px;
+}
+
+.catalog-card .error {
+  color: var(--danger);
+  font-size: 0.78rem;
+  margin-top: 8px;
+}
+
+.catalog-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.catalog-actions button {
+  flex: 1;
+  background: rgba(59, 130, 246, 0.15);
+  color: rgba(96, 165, 250, 1);
+  border: none;
+  border-radius: 12px;
+  padding: 8px;
+  cursor: pointer;
+  font-size: 0.78rem;
+}
+
+.palette {
+  margin-top: 16px;
+}
+
+.node-group {
+  margin-bottom: 28px;
+}
+
+.node-group h3 {
+  margin: 0 0 12px;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.node-type {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed rgba(148, 163, 184, 0.25);
+  color: var(--text);
+  background: rgba(30, 41, 59, 0.7);
+  margin-bottom: 10px;
+  cursor: grab;
+  transition: transform 0.15s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.node-type:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(30, 64, 175, 0.35);
+  transform: translateY(-1px);
+}
+
+.node-type span {
+  font-weight: 600;
+}
+
+.canvas {
+  position: relative;
+  background: var(--canvas);
+  overflow: hidden;
+}
+
+.canvas::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+  background-size: 80px 80px;
+  mask-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.8), transparent 70%);
+  pointer-events: none;
+}
+
+.canvas-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.node-card {
+  position: absolute;
+  min-width: 200px;
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.55);
+  padding: 16px 18px;
+  cursor: grab;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.node-card:active {
+  cursor: grabbing;
+  transform: scale(1.02);
+}
+
+.node-card.selected {
+  border-color: var(--accent);
+  box-shadow: 0 25px 55px rgba(56, 189, 248, 0.35);
+}
+
+.node-card .title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.node-card .title strong {
+  font-size: 0.98rem;
+  letter-spacing: 0.04em;
+}
+
+.node-card .subtitle {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.node-card .tag {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.9);
+  font-weight: 700;
+}
+
+.node-task {
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.node-task .tag {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.9));
+}
+
+.node-pass .tag {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.9), rgba(16, 185, 129, 0.9));
+}
+
+.node-wait .tag {
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.9), rgba(251, 191, 36, 0.9));
+  color: rgba(63, 39, 0, 0.85);
+}
+
+.node-choice .tag {
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.9), rgba(79, 70, 229, 0.9));
+}
+
+.node-parallel .tag {
+  background: linear-gradient(135deg, rgba(251, 146, 60, 0.9), rgba(249, 115, 22, 0.9));
+}
+
+.node-map .tag {
+  background: linear-gradient(135deg, rgba(236, 72, 153, 0.9), rgba(219, 39, 119, 0.9));
+}
+
+.node-fail .tag {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.9), rgba(239, 68, 68, 0.9));
+}
+
+.node-succeed .tag {
+  background: linear-gradient(135deg, rgba(45, 212, 191, 0.9), rgba(20, 184, 166, 0.9));
+}
+
+.node-card .open-branch {
+  margin-top: 10px;
+  border: none;
+  border-radius: 12px;
+  padding: 8px 14px;
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.82rem;
+}
+
+.node-card .open-branch:hover {
+  background: rgba(56, 189, 248, 0.3);
+}
+
+.link-canvas {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.edge-label {
+  fill: rgba(148, 163, 184, 0.7);
+  font-size: 0.68rem;
+  text-anchor: middle;
+}
+
+.config-content h2 {
+  margin-top: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.05em;
+}
+
+.form-field {
+  margin-bottom: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-field label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.form-field input,
+.form-field textarea,
+.form-field select {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--text);
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 0.9rem;
+  outline: none;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.form-field textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.form-field input:focus,
+.form-field textarea:focus,
+.form-field select:focus {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(17, 24, 39, 0.95);
+}
+
+.grid-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.parameters {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  padding: 14px;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.parameter-item {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) 42px;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.parameter-item:last-child {
+  margin-bottom: 0;
+}
+
+.parameter-item input,
+.parameter-item select {
+  width: 100%;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 0.85rem;
+}
+
+.parameter-item button {
+  border: none;
+  border-radius: 10px;
+  background: rgba(248, 113, 113, 0.25);
+  color: rgba(248, 113, 113, 0.92);
+  cursor: pointer;
+}
+
+.parameter-item button:hover {
+  background: rgba(248, 113, 113, 0.35);
+}
+
+.button-line {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.button-line button {
+  flex: 1;
+  border: none;
+  border-radius: 12px;
+  padding: 10px;
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--accent);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.button-line button:hover {
+  background: rgba(56, 189, 248, 0.25);
+}
+
+.switch-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.switch-row label {
+  margin: 0;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 0.88rem;
+}
+
+.toggle {
+  position: relative;
+  width: 42px;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  transition: background 0.2s ease;
+  cursor: pointer;
+}
+
+.toggle[data-active="true"] {
+  background: rgba(56, 189, 248, 0.65);
+}
+
+.toggle::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #0f172a;
+  transition: transform 0.2s ease;
+}
+
+.toggle[data-active="true"]::after {
+  transform: translateX(20px);
+}
+
+.notice {
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  font-size: 0.82rem;
+  background: rgba(34, 197, 94, 0.18);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  color: rgba(167, 243, 208, 1);
+}
+
+.notice.warning {
+  background: rgba(250, 204, 21, 0.18);
+  border-color: rgba(250, 204, 21, 0.3);
+  color: rgba(253, 224, 71, 1);
+}
+
+.notice.danger {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.3);
+  color: rgba(254, 202, 202, 1);
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.chip {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-muted);
+}
+
+.flow-breadcrumb {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin-bottom: 20px;
+}
+
+.flow-breadcrumb button {
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.flow-breadcrumb button.active {
+  color: var(--accent);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.74);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 90;
+}
+
+.modal {
+  background: rgba(15, 23, 42, 0.98);
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.55);
+  width: min(480px, 90vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal header {
+  padding: 20px 24px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+}
+
+.modal .modal-body {
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.modal footer {
+  padding: 18px 24px;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.modal footer button {
+  min-width: 120px;
+  border: none;
+  border-radius: 14px;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.modal footer .primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0f172a;
+}
+
+.modal footer .ghost {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-muted);
+}
+
+.validation-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.validation-panel .error-item {
+  border-radius: 14px;
+  border: 1px solid rgba(248, 113, 113, 0.32);
+  background: rgba(248, 113, 113, 0.12);
+  padding: 12px 14px;
+  font-size: 0.85rem;
+  color: rgba(254, 202, 202, 1);
+}
+
+.validation-panel .error-item strong {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.toast-container {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 100;
+}
+
+.toast {
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 12px 18px;
+  font-size: 0.88rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.5);
+}
+
+.toast.success {
+  border-color: rgba(34, 197, 94, 0.3);
+  color: rgba(167, 243, 208, 1);
+}
+
+.toast.error {
+  border-color: rgba(248, 113, 113, 0.3);
+  color: rgba(254, 202, 202, 1);
+}
+
+.empty-state {
+  padding: 28px;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.55);
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.branch-card {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  background: rgba(30, 41, 59, 0.7);
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.branch-card button {
+  border: none;
+  border-radius: 999px;
+  padding: 6px 12px;
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.branch-card button:hover {
+  background: rgba(56, 189, 248, 0.3);
+}
+
+@media (max-width: 1280px) {
+  .app-body {
+    grid-template-columns: 280px 1fr 320px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .app-body {
+    grid-template-columns: 260px 1fr;
+  }
+  .config-panel {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .header-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}

--- a/dynaflow/ui/static/styles.css
+++ b/dynaflow/ui/static/styles.css
@@ -107,6 +107,47 @@ body {
   margin-left: 14px;
 }
 
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  margin-left: 14px;
+  font-size: 0.86rem;
+}
+
+.breadcrumb-item {
+  display: flex;
+  align-items: center;
+}
+
+.breadcrumb-separator {
+  margin: 0 8px;
+  color: var(--text-muted);
+}
+
+.breadcrumb-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: 0.86rem;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.breadcrumb-link:hover {
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.breadcrumb-current {
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 0.86rem;
+  font-weight: 600;
+  padding: 2px 4px;
+}
+
 .header-actions {
   display: flex;
   gap: 12px;
@@ -262,7 +303,8 @@ body {
   color: var(--text);
   background: rgba(30, 41, 59, 0.7);
   margin-bottom: 10px;
-  cursor: grab;
+  cursor: pointer;
+  user-select: none;
   transition: transform 0.15s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
@@ -272,8 +314,36 @@ body {
   transform: translateY(-1px);
 }
 
+.node-type .node-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
 .node-type span {
   font-weight: 600;
+}
+
+.node-type .add-node-btn {
+  background: rgba(56, 189, 248, 0.8);
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  color: white;
+  font-weight: bold;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.node-type .add-node-btn:hover {
+  background: rgba(56, 189, 248, 1);
+  transform: scale(1.1);
 }
 
 .canvas {
@@ -308,12 +378,23 @@ body {
   box-shadow: 0 20px 45px rgba(15, 23, 42, 0.55);
   padding: 16px 18px;
   cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .node-card:active {
   cursor: grabbing;
   transform: scale(1.02);
+}
+
+.node-card.dragging {
+  cursor: grabbing;
+  transform: scale(1.05);
+  z-index: 1000;
+  box-shadow: 0 30px 60px rgba(56, 189, 248, 0.4);
 }
 
 .node-card.selected {
@@ -404,6 +485,20 @@ body {
   position: absolute;
   inset: 0;
   pointer-events: none;
+  z-index: 1;
+}
+
+.link-canvas path {
+  stroke: var(--accent);
+  stroke-width: 2;
+  fill: none;
+  opacity: 0.8;
+}
+
+.link-canvas text {
+  fill: var(--text);
+  font-size: 11px;
+  font-weight: 500;
 }
 
 .edge-label {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jsonpath-ng~=1.7.0
 jsonschema~=4.23.0
 jsonschema-specifications~=2024.10.1
 referencing~=0.35.1
+click~=8.3.0

--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,7 @@ setup(
         "Source": "https://github.com/sgg10/dynaflow/",
         "Repository": "https://github.com/sgg10/dynaflow/",
     },
+    entry_points={
+        "console_scripts": ["dynaflow=dynaflow.cli:cli"],
+    },
 )

--- a/tests/sample_catalog/__init__.py
+++ b/tests/sample_catalog/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+
+class DummyFunction:
+    def __call__(self, *args, **kwargs):  # pragma: no cover - trivial
+        return args, kwargs
+
+
+def _make_version(version: str):
+    return {
+        'version': version,
+        'description': f'Demo function v{version}',
+        'function': DummyFunction(),
+        'metadata': {'version': version}
+    }
+
+
+function_catalog = {
+    'demo_function': {
+        '1': _make_version('1'),
+        '2': _make_version('2')
+    }
+}

--- a/tests/ui/test_catalog_manager.py
+++ b/tests/ui/test_catalog_manager.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dynaflow.ui.catalogs import CatalogManager
+
+
+def create_manager(tmp_path: Path) -> CatalogManager:
+    storage = tmp_path / "catalogs.json"
+    return CatalogManager(storage_path=storage)
+
+
+def test_install_and_remove_local_catalog(tmp_path):
+    manager = create_manager(tmp_path)
+
+    record = manager.install_catalog(
+        pip_url=None,
+        alias="demo",
+        module="tests.sample_catalog",
+        attribute="function_catalog",
+    )
+
+    assert record.alias == "demo"
+    assert record.functions, "functions should be extracted"
+    assert record.error is None
+
+    catalogs = manager.list_catalogs()
+    assert len(catalogs) == 1
+    assert catalogs[0].alias == "demo"
+
+    aggregated = manager.aggregated_functions()
+    assert aggregated
+    assert aggregated[0]["name"] == "demo_function"
+    versions = {version["version"] for version in aggregated[0]["versions"]}
+    assert {"1", "2"} <= versions
+
+    refreshed = manager.refresh("demo")
+    assert refreshed.functions
+
+    manager.remove("demo")
+    assert not manager.list_catalogs()
+
+
+def test_parse_git_spec_infers_metadata(tmp_path):
+    manager = create_manager(tmp_path)
+    spec = "git+https://example.com/team/catalog.git@main#egg=my_catalog"
+    parsed = manager._parse_spec(spec)  # noqa: SLF001 - testing helper
+    assert parsed["module"] == "my_catalog"
+    assert parsed["alias"] == "catalog"
+
+
+def test_build_install_spec_injects_auth(tmp_path):
+    manager = create_manager(tmp_path)
+    spec = "git+https://example.com/repo.git"
+    result = manager._build_install_spec(  # noqa: SLF001 - testing helper
+        spec,
+        {"type": "basic", "username": "user", "password": "pass"},
+    )
+    assert "user:pass" in result


### PR DESCRIPTION
## Summary
- add a Click-based CLI entry point and HTTP server to host a drag-and-drop DynaFlow web UI
- implement a catalog manager that installs, loads, and aggregates function registries for the UI and persist configuration
- add a bundled UI built with a lightweight React-style runtime plus catalog management modal and flow canvas, with tests covering catalog management

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d32125e770832998e6bc112e16cb2b