### PR TITLE
Fix flow editor transitions, links and canvas interactions

### DIFF
--- a/dynaflow/ui/static/app.js
+++ b/dynaflow/ui/static/app.js
@@ -1517,9 +1517,9 @@
               d: path,
               fill: 'none',
               stroke: '#38bdf8',
-              strokeWidth: 3,
-              strokeLinecap: 'round',
-              strokeLinejoin: 'round',
+              'stroke-width': 3,
+              'stroke-linecap': 'round',
+              'stroke-linejoin': 'round',
               opacity: 0.9
             }),
             h('path', {
@@ -2995,6 +2995,7 @@
           onSelectNode: handleSelectNode,
           onMoveNode: handleMoveNode,
           onOpenFlow: handleNavigateFlow,
+          onMeasureNode: handleMeasureNodeRect,
           pan,
           onPanChange: handlePanChange
         }),

--- a/dynaflow/ui/static/app.js
+++ b/dynaflow/ui/static/app.js
@@ -1112,6 +1112,7 @@
     onSelectNode,
     onMoveNode,
     onOpenFlow,
+    onMeasureNode,
     pan,
     onPanChange
   }) {
@@ -1229,6 +1230,7 @@
                 onSelect: onSelectNode,
                 onMove: onMoveNode,
                 onOpenFlow,
+                onMeasure: onMeasureNode,
                 isStart: flow.startNodeId === node.id,
                 isEnd: Boolean(node.transitions.end)
               });
@@ -1238,7 +1240,16 @@
     ]);
   }
 
-  function NodeCard({ node, selected, onSelect, onMove, onOpenFlow, isStart, isEnd }) {
+  function NodeCard({
+    node,
+    selected,
+    onSelect,
+    onMove,
+    onOpenFlow,
+    onMeasure,
+    isStart,
+    isEnd
+  }) {
     const ref = useRef(null);
 
     const handleDoubleClick = useCallback(() => {
@@ -1256,7 +1267,7 @@
 
     const handleMouseDown = useCallback((event) => {
       if (event.button !== 0) return;
-      
+
       console.log('🖱️ MOUSEDOWN en nodo:', node.id);
       event.preventDefault();
       
@@ -1296,10 +1307,73 @@
           console.log('🛑 FIN ARRASTRE del nodo:', node.id);
         }
       };
-      
+
       document.addEventListener('mousemove', handleMouseMove);
       document.addEventListener('mouseup', handleMouseUp);
     }, [node.id, node.position, onMove]);
+
+    useEffect(() => {
+      if (!ref.current || !onMeasure) {
+        return;
+      }
+
+      const element = ref.current;
+      let frame = null;
+
+      const updateRect = () => {
+        if (!element) {
+          return;
+        }
+        onMeasure(node.id, {
+          left: node.position.x,
+          top: node.position.y,
+          width: element.offsetWidth,
+          height: element.offsetHeight
+        });
+      };
+
+      frame = requestAnimationFrame(updateRect);
+
+      let resizeObserver = null;
+      if (typeof ResizeObserver === 'function') {
+        resizeObserver = new ResizeObserver(() => {
+          if (frame) {
+            cancelAnimationFrame(frame);
+          }
+          frame = requestAnimationFrame(updateRect);
+        });
+        resizeObserver.observe(element);
+      }
+
+      return () => {
+        if (frame) {
+          cancelAnimationFrame(frame);
+        }
+        if (resizeObserver) {
+          resizeObserver.disconnect();
+        }
+      };
+    }, [
+      node.id,
+      node.position.x,
+      node.position.y,
+      node.name,
+      node.comment,
+      node.type,
+      node.transitions.end,
+      node.branchFlowIds && node.branchFlowIds.length,
+      onMeasure
+    ]);
+
+    useEffect(() => {
+      if (!onMeasure) {
+        return () => {};
+      }
+      const nodeId = node.id;
+      return () => {
+        onMeasure(nodeId, null);
+      };
+    }, [node.id, onMeasure]);
 
     const className = `${getNodeClass(node.type)}${selected ? ' selected' : ''}`;
 
@@ -1512,6 +1586,17 @@
       onChange(newValue ? newValue : null);
     };
 
+    const renderOption = (option) =>
+      h(
+        'option',
+        {
+          key: option.id,
+          value: option.id,
+          selected: option.id === currentValue
+        },
+        option.label
+      );
+
     return h(
       'select',
       {
@@ -1520,10 +1605,8 @@
         onChange: handleChange
       },
       [
-        h('option', { value: '' }, '— None —'),
-        ...nextOptions.map((option) =>
-          h('option', { key: option.id, value: option.id }, option.label)
-        )
+        h('option', { value: '', selected: currentValue === '' }, '— None —'),
+        ...nextOptions.map(renderOption)
       ]
     );
   }
@@ -2577,40 +2660,29 @@
     useCatalogs(dispatch);
     useToasts(state, dispatch);
 
-    useEffect(() => {
-      if (!flow || !canvasRef.current) return;
-
-      // Usar requestAnimationFrame para asegurar que el layout esté completo
-      const captureRects = () => {
-        const container = canvasRef.current;
-        if (!container) return;
-        
-        const rects = {};
-        const containerRect = container.getBoundingClientRect();
-        
-        // Buscar nodos directamente en el container
-        flow.order.forEach((nodeId) => {
-          const element = container.querySelector(`[data-node-id="${nodeId}"]`);
-          if (element) {
-            const rect = element.getBoundingClientRect();
-            rects[nodeId] = {
-              left: rect.left - containerRect.left,
-              top: rect.top - containerRect.top,
-              width: rect.width,
-              height: rect.height
-            };
-            console.log('📐 Rect capturado para', nodeId, ':', rects[nodeId]);
-          } else {
-            console.log('❌ No se encontró elemento para', nodeId);
+    const handleMeasureNodeRect = useCallback((nodeId, rect) => {
+      setNodeRects((prev) => {
+        if (rect) {
+          const existing = prev[nodeId];
+          if (
+            existing &&
+            existing.left === rect.left &&
+            existing.top === rect.top &&
+            existing.width === rect.width &&
+            existing.height === rect.height
+          ) {
+            return prev;
           }
-        });
-        
-        console.log('📐 RequestAnimationFrame: nodeRects capturados:', Object.keys(rects).length);
-        setNodeRects(rects);
-      };
-
-      requestAnimationFrame(captureRects);
-    }, [flow, state.revision]);
+          return { ...prev, [nodeId]: rect };
+        }
+        if (!prev[nodeId]) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[nodeId];
+        return next;
+      });
+    }, []);
 
     useEffect(() => {
       if (!flow) {

--- a/dynaflow/ui/static/app.js
+++ b/dynaflow/ui/static/app.js
@@ -23,15 +23,29 @@
   ];
 
   const CHOICE_OPERATORS = [
-    "StringEquals",
-    "StringMatches",
+    "BooleanEquals",
+    "IsBoolean",
+    "IsElementPresent",
+    "IsNull",
+    "IsNumeric",
+    "IsString",
+    "IsTimestamp",
     "NumericEquals",
     "NumericGreaterThan",
+    "NumericGreaterThanEquals",
     "NumericLessThan",
-    "BooleanEquals",
+    "NumericLessThanEquals",
+    "StringEquals",
+    "StringGreaterThan",
+    "StringGreaterThanEquals",
+    "StringLessThan",
+    "StringLessThanEquals",
+    "StringMatches",
     "TimestampEquals",
+    "TimestampGreaterThan",
+    "TimestampGreaterThanEquals",
     "TimestampLessThan",
-    "TimestampGreaterThan"
+    "TimestampLessThanEquals"
   ];
 
   const WAIT_MODES = [
@@ -40,6 +54,9 @@
     { id: "secondsPath", label: "Seconds Path" },
     { id: "timestampPath", label: "Timestamp Path" }
   ];
+
+  const DEFAULT_NODE_WIDTH = 220;
+  const DEFAULT_NODE_HEIGHT = 110;
 
   const NODE_NAME_PREFIX = {
     Task: "Task",
@@ -1209,7 +1226,7 @@
         onWheel: handleWheel
       },
       [
-        h(LinkLayer, { edges, rects: nodeRects, pan }),
+        h(LinkLayer, { edges, rects: nodeRects, nodes: flow ? flow.nodes : {}, pan }),
         h(
           'div',
           {
@@ -1413,18 +1430,28 @@
     );
   }
 
-  function LinkLayer({ edges, rects, pan }) {
-    console.log('🔗 LinkLayer render:', {
-      edgesCount: edges.length,
-      edges: edges,
-      rectsKeys: Object.keys(rects)
-    });
-    
+  function LinkLayer({ edges, rects, nodes, pan }) {
     if (!edges.length) {
-      console.log('❌ No hay edges para renderizar');
       return null;
     }
-    
+
+    const resolveRect = (id) => {
+      if (rects && rects[id]) {
+        return rects[id];
+      }
+      const node = nodes && nodes[id];
+      if (!node) {
+        return null;
+      }
+      const position = node.position || { x: 0, y: 0 };
+      return {
+        left: position.x,
+        top: position.y,
+        width: DEFAULT_NODE_WIDTH,
+        height: DEFAULT_NODE_HEIGHT
+      };
+    };
+
     return h(
       'svg',
       {
@@ -1435,64 +1462,77 @@
           position: 'absolute',
           top: 0,
           left: 0,
-          zIndex: 10,
           transform: `translate(${pan.x}px, ${pan.y}px)`
         }
       },
       edges.map((edge) => {
-        const source = rects[edge.from];
-        const target = rects[edge.to];
-        console.log('🎯 Procesando edge:', edge.id, { 
-          from: edge.from, 
-          to: edge.to, 
-          hasSource: !!source, 
-          hasTarget: !!target 
-        });
-        
-        if (!source || !target) {
-          console.log('❌ Edge sin rects:', edge.id, { source, target });
+        if (!edge || edge.from === edge.to) {
           return null;
         }
-        const startX = source.left + source.width;
-        const startY = source.top + source.height / 2;
-        const endX = target.left;
-        const endY = target.top + target.height / 2;
-        
-        // Path simple y directo - línea recta con una pequeña curva
-        const midX = startX + (endX - startX) * 0.6;
-        const path = `M ${startX} ${startY} Q ${midX} ${startY} ${endX - 10} ${endY}`;
-        
-        console.log('🎨 DIBUJANDO flecha simple:', {
-          edge: edge.id,
-          coords: `${startX},${startY} -> ${endX},${endY}`,
-          path,
-          sourceSize: `${source.width}x${source.height}`,
-          targetSize: `${target.width}x${target.height}`
-        });
-        
+
+        const source = resolveRect(edge.from);
+        const target = resolveRect(edge.to);
+
+        if (!source || !target) {
+          return null;
+        }
+
+        const sourceX = source.left + source.width;
+        const sourceY = source.top + source.height / 2;
+        const targetX = target.left;
+        const targetY = target.top + target.height / 2;
+
+        const direction = targetX >= sourceX ? 1 : -1;
+        const deltaX = Math.abs(targetX - sourceX);
+        const curve = Math.min(Math.max(deltaX * 0.5, 48), 240);
+        const control1X = sourceX + curve * direction;
+        const control2X = targetX - curve * direction;
+        const control1Y = sourceY;
+        const control2Y = targetY;
+
+        const dx = targetX - sourceX;
+        const dy = targetY - sourceY;
+        const angle = Math.atan2(dy, dx === 0 ? direction * 0.0001 : dx);
+        const arrowTipX = targetX - direction * 6;
+        const arrowTipY = targetY;
+        const lineEndX = arrowTipX - Math.cos(angle) * 8;
+        const lineEndY = arrowTipY - Math.sin(angle) * 8;
+        const path = `M ${sourceX} ${sourceY} C ${control1X} ${control1Y} ${control2X} ${control2Y} ${lineEndX} ${lineEndY}`;
+
+        const headLength = 10;
+        const leftX = arrowTipX - headLength * Math.cos(angle - Math.PI / 6);
+        const leftY = arrowTipY - headLength * Math.sin(angle - Math.PI / 6);
+        const rightX = arrowTipX - headLength * Math.cos(angle + Math.PI / 6);
+        const rightY = arrowTipY - headLength * Math.sin(angle + Math.PI / 6);
+        const arrowHead = `M ${arrowTipX} ${arrowTipY} L ${leftX} ${leftY} L ${rightX} ${rightY} Z`;
+
+        const labelX = sourceX + (targetX - sourceX) * 0.5;
+        const labelY = sourceY + (targetY - sourceY) * 0.5 - 8;
+
         return h(
           'g',
-          { key: edge.id },
+          { key: edge.id, className: 'link-edge' },
           [
             h('path', {
               d: path,
               fill: 'none',
               stroke: '#38bdf8',
-              strokeWidth: 4,
-              opacity: 1
+              strokeWidth: 3,
+              strokeLinecap: 'round',
+              strokeLinejoin: 'round',
+              opacity: 0.9
             }),
-            h('circle', {
-              cx: endX - 10,
-              cy: endY,
-              r: 6,
-              fill: '#38bdf8'
+            h('path', {
+              d: arrowHead,
+              fill: '#38bdf8',
+              opacity: 0.95
             }),
             edge.label
               ? h(
                   'text',
                   {
-                    x: midX,
-                    y: startY + (endY - startY) * 0.5 - 6,
+                    x: labelX,
+                    y: labelY,
                     className: 'edge-label'
                   },
                   edge.label
@@ -2423,35 +2463,70 @@
       dispatch({ type: 'REMOVE_PARALLEL_BRANCH', flowId, nodeId: node.id, index });
     };
 
+    const renderBranch = (branchId, index) => {
+      const branch = flows[branchId];
+      const options = branch
+        ? branch.order.map((id) => ({ id, label: branch.nodes[id].name }))
+        : [];
+      const startNodeId = branch && branch.startNodeId ? branch.startNodeId : '';
+      const hasNodes = options.length > 0;
+
+      const handleStartChange = (event) => {
+        const value = event.target.value;
+        if (!value || !branch) {
+          return;
+        }
+        dispatch({ type: 'SET_FLOW_START', flowId: branchId, nodeId: value });
+      };
+
+      return h('div', { className: 'branch-card', key: branchId }, [
+        h('div', { className: 'branch-card-header' }, [
+          h('span', { className: 'branch-name' }, branch ? branch.label : `Branch ${index + 1}`),
+          h('div', { className: 'branch-actions' }, [
+            h(
+              'button',
+              { onClick: () => onNavigateFlow(branchId) },
+              'Open'
+            ),
+            branches.length > 1
+              ? h(
+                  'button',
+                  {
+                    onClick: () => removeBranch(index),
+                    style: {
+                      background: 'rgba(248,113,113,0.2)',
+                      color: 'rgba(248,113,113,0.9)'
+                    }
+                  },
+                  'Remove'
+                )
+              : null
+          ])
+        ]),
+        hasNodes
+          ? h('div', { className: 'form-field condensed' }, [
+              h('label', null, 'Start state'),
+              h(
+                'select',
+                {
+                  value: startNodeId,
+                  onChange: handleStartChange
+                },
+                [
+                  h('option', { value: '' }, '— Select —'),
+                  ...options.map((option) =>
+                    h('option', { key: option.id, value: option.id }, option.label)
+                  )
+                ]
+              )
+            ])
+          : h('div', { className: 'branch-hint' }, 'Add states to this branch to choose where it starts.')
+      ]);
+    };
+
     return h(Fragment, null, [
       branches.length
-        ? branches.map((branchId, index) => {
-            const branch = flows[branchId];
-            return h('div', { className: 'branch-card', key: branchId }, [
-              h('span', null, branch ? branch.label : `Branch ${index + 1}`),
-              h('div', null, [
-                h(
-                  'button',
-                  { onClick: () => onNavigateFlow(branchId) },
-                  'Open'
-                ),
-                branches.length > 1
-                  ? h(
-                      'button',
-                      {
-                        onClick: () => removeBranch(index),
-                        style: {
-                          marginLeft: '8px',
-                          background: 'rgba(248,113,113,0.2)',
-                          color: 'rgba(248,113,113,0.9)'
-                        }
-                      },
-                      'Remove'
-                    )
-                  : null
-              ])
-            ]);
-          })
+        ? branches.map((branchId, index) => renderBranch(branchId, index))
         : h('div', { className: 'empty-state' }, 'No branches defined yet.'),
       h(
         'button',
@@ -2689,6 +2764,14 @@
         return;
       }
       setPan({ x: 0, y: 0 });
+    }, [flow && flow.id]);
+
+    useEffect(() => {
+      if (!flow) {
+        setNodeRects({});
+        return;
+      }
+      setNodeRects({});
     }, [flow && flow.id]);
 
     const edges = useMemo(() => computeEdges(flow), [flow, state.revision]);

--- a/dynaflow/ui/static/app.js
+++ b/dynaflow/ui/static/app.js
@@ -1111,16 +1111,36 @@
     onDropNode,
     onSelectNode,
     onMoveNode,
-    onOpenFlow
+    onOpenFlow,
+    pan,
+    onPanChange
   }) {
+    const panStateRef = useRef(pan);
+    const dragStartRef = useRef({ x: 0, y: 0 });
+    const pointerStartRef = useRef({ x: 0, y: 0 });
+    const [isPanning, setIsPanning] = useState(false);
+
+    useEffect(() => {
+      panStateRef.current = pan;
+    }, [pan]);
+
+    const attachCanvasRef = useCallback(
+      (element) => {
+        if (canvasRef) {
+          canvasRef.current = element;
+        }
+      },
+      [canvasRef]
+    );
+
     const handleDrop = (event) => {
       event.preventDefault();
       const nodeType = event.dataTransfer.getData('application/x-node-type');
-      if (!nodeType || !flow) return;
+      if (!nodeType || !flow || !canvasRef || !canvasRef.current) return;
       const rect = canvasRef.current.getBoundingClientRect();
       const position = {
-        x: event.clientX - rect.left - 100,
-        y: event.clientY - rect.top - 40
+        x: event.clientX - rect.left - pan.x - 100,
+        y: event.clientY - rect.top - pan.y - 40
       };
       onDropNode(nodeType, position);
     };
@@ -1130,11 +1150,75 @@
       event.dataTransfer.dropEffect = 'copy';
     };
 
-    return h('div', { className: 'canvas', onDrop: handleDrop, onDragOver: handleDragOver }, [
-      h(LinkLayer, { edges, rects: nodeRects }),
-      h(
-        'div',
-        { className: 'canvas-inner', ref: canvasRef },
+    const handleBackgroundMouseDown = useCallback(
+      (event) => {
+        if (!canvasRef || !canvasRef.current) return;
+        if (event.button !== 0) return;
+        if (event.target !== canvasRef.current) return;
+
+        event.preventDefault();
+        pointerStartRef.current = { x: event.clientX, y: event.clientY };
+        dragStartRef.current = { ...panStateRef.current };
+        setIsPanning(true);
+        document.body.style.cursor = 'grabbing';
+
+        const handleMouseMove = (moveEvent) => {
+          const dx = moveEvent.clientX - pointerStartRef.current.x;
+          const dy = moveEvent.clientY - pointerStartRef.current.y;
+          onPanChange({
+            x: dragStartRef.current.x + dx,
+            y: dragStartRef.current.y + dy
+          });
+        };
+
+        const handleMouseUp = () => {
+          document.removeEventListener('mousemove', handleMouseMove);
+          document.removeEventListener('mouseup', handleMouseUp);
+          document.body.style.cursor = '';
+          setIsPanning(false);
+        };
+
+        document.addEventListener('mousemove', handleMouseMove);
+        document.addEventListener('mouseup', handleMouseUp);
+      },
+      [canvasRef, onPanChange]
+    );
+
+    const handleWheel = useCallback(
+      (event) => {
+        if (event.ctrlKey) {
+          return;
+        }
+        event.preventDefault();
+        const nextPan = {
+          x: panStateRef.current.x - event.deltaX,
+          y: panStateRef.current.y - event.deltaY
+        };
+        onPanChange(nextPan);
+      },
+      [onPanChange]
+    );
+
+    return h(
+      'div',
+      {
+        className: 'canvas',
+        onDrop: handleDrop,
+        onDragOver: handleDragOver,
+        onWheel: handleWheel
+      },
+      [
+        h(LinkLayer, { edges, rects: nodeRects, pan }),
+        h(
+          'div',
+          {
+            className: `canvas-inner${isPanning ? ' is-panning' : ''}`,
+            ref: attachCanvasRef,
+            onMouseDown: handleBackgroundMouseDown,
+            style: {
+              transform: `translate(${pan.x}px, ${pan.y}px)`
+            }
+          },
         flow && flow.order.length
           ? flow.order.map((nodeId) => {
               const node = flow.nodes[nodeId];
@@ -1144,7 +1228,9 @@
                 selected: selection && selection.nodeId === node.id,
                 onSelect: onSelectNode,
                 onMove: onMoveNode,
-                onOpenFlow
+                onOpenFlow,
+                isStart: flow.startNodeId === node.id,
+                isEnd: Boolean(node.transitions.end)
               });
             })
           : h('div', { className: 'empty-state' }, 'Drag a node from the palette to begin designing your flow.')
@@ -1152,7 +1238,7 @@
     ]);
   }
 
-  function NodeCard({ node, selected, onSelect, onMove, onOpenFlow }) {
+  function NodeCard({ node, selected, onSelect, onMove, onOpenFlow, isStart, isEnd }) {
     const ref = useRef(null);
 
     const handleDoubleClick = useCallback(() => {
@@ -1232,6 +1318,8 @@
         onDoubleClick: handleDoubleClick
       },
       [
+        isStart ? h('span', { className: 'node-marker node-marker-start', title: 'Start state' }) : null,
+        isEnd ? h('span', { className: 'node-marker node-marker-end', title: 'End state' }) : null,
         h('div', { className: 'title' }, [
           h('strong', null, node.name),
           h('span', { className: 'tag' }, node.type)
@@ -1251,9 +1339,9 @@
     );
   }
 
-  function LinkLayer({ edges, rects }) {
-    console.log('🔗 LinkLayer render:', { 
-      edgesCount: edges.length, 
+  function LinkLayer({ edges, rects, pan }) {
+    console.log('🔗 LinkLayer render:', {
+      edgesCount: edges.length,
       edges: edges,
       rectsKeys: Object.keys(rects)
     });
@@ -1265,11 +1353,17 @@
     
     return h(
       'svg',
-      { 
+      {
         className: 'link-canvas',
         width: '100%',
         height: '100%',
-        style: { position: 'absolute', top: 0, left: 0, zIndex: 10 }
+        style: {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          zIndex: 10,
+          transform: `translate(${pan.x}px, ${pan.y}px)`
+        }
       },
       edges.map((edge) => {
         const source = rects[edge.from];
@@ -1411,30 +1505,17 @@
   }
 
   function NextStateSelect({ node, nextOptions, onChange }) {
-    const [localValue, setLocalValue] = useState(node.transitions.next || '');
-    
-    // Sincronizar valor local cuando cambia el nodo
-    useEffect(() => {
-      const expectedValue = node.transitions.next || '';
-      console.log('🔄 NextStateSelect sync:', { 
-        localValue, 
-        expectedValue, 
-        nodeId: node.id 
-      });
-      setLocalValue(expectedValue);
-    }, [node.transitions.next, node.id]);
-    
+    const currentValue = node.transitions.next || '';
+
     const handleChange = (event) => {
       const newValue = event.target.value;
-      console.log('🔄 NextStateSelect handleChange:', { from: localValue, to: newValue });
-      setLocalValue(newValue);
-      onChange(event);
+      onChange(newValue ? newValue : null);
     };
-    
+
     return h(
       'select',
       {
-        value: localValue,
+        value: currentValue,
         disabled: node.transitions.end,
         onChange: handleChange
       },
@@ -1448,31 +1529,18 @@
   }
 
   function NodeGeneralSettings({ flow, node, dispatch }) {
-    const selectRef = useRef(null);
-    
     console.log('🔧 NodeGeneralSettings render:', {
       nodeId: node.id,
       nodeName: node.name,
       currentNext: node.transitions.next,
       allTransitions: node.transitions
     });
-    
+
     const nextOptions = flow.order
       .filter((id) => id !== node.id)
       .map((id) => ({ id, label: flow.nodes[id].name }));
-      
+
     console.log('🔧 NextOptions disponibles:', nextOptions);
-    
-    // Forzar sincronización del select cuando cambia node.transitions.next
-    useEffect(() => {
-      if (selectRef.current) {
-        const expectedValue = node.transitions.next || '';
-        if (selectRef.current.value !== expectedValue) {
-          console.log('🔧 Sincronizando select:', selectRef.current.value, '->', expectedValue);
-          selectRef.current.value = expectedValue;
-        }
-      }
-    }, [node.transitions.next]);
 
     const handleNameChange = useCallback((event) => {
       const value = event.target.value;
@@ -1511,12 +1579,11 @@
       });
     };
 
-    const handleNextChange = (event) => {
-      const nextValue = event.target.value || null;
-      console.log('🔄 handleNextChange:', { 
-        from: node.transitions.next, 
-        to: nextValue, 
-        nodeId: node.id 
+    const handleNextChange = (nextValue) => {
+      console.log('🔄 handleNextChange:', {
+        from: node.transitions.next,
+        to: nextValue,
+        nodeId: node.id
       });
       dispatch({
         type: 'UPDATE_NODE',
@@ -1573,11 +1640,7 @@
       supportsNextTransition(node.type)
         ? h('div', { className: 'form-field' }, [
             h('label', null, 'Next state'),
-            h(NextStateSelect, {
-              node,
-              nextOptions,
-              onChange: handleNextChange
-            })
+            h(NextStateSelect, { node, nextOptions, onChange: handleNextChange })
           ])
         : null,
       h('div', { className: 'switch-row' }, [
@@ -2503,9 +2566,10 @@
     const [nodeRects, setNodeRects] = useState({});
     const [installPending, setInstallPending] = useState(false);
     const [installError, setInstallError] = useState('');
+    const [pan, setPan] = useState({ x: 0, y: 0 });
     const canvasRef = useRef(null);
     const flow = state.flows[state.currentFlowId];
-    
+
     // Exponer estado para debugging
     window.debugState = state;
     window.debugDispatch = dispatch;
@@ -2515,7 +2579,7 @@
 
     useEffect(() => {
       if (!flow || !canvasRef.current) return;
-      
+
       // Usar requestAnimationFrame para asegurar que el layout esté completo
       const captureRects = () => {
         const container = canvasRef.current;
@@ -2544,9 +2608,16 @@
         console.log('📐 RequestAnimationFrame: nodeRects capturados:', Object.keys(rects).length);
         setNodeRects(rects);
       };
-      
+
       requestAnimationFrame(captureRects);
     }, [flow, state.revision]);
+
+    useEffect(() => {
+      if (!flow) {
+        return;
+      }
+      setPan({ x: 0, y: 0 });
+    }, [flow && flow.id]);
 
     const edges = useMemo(() => computeEdges(flow), [flow, state.revision]);
 
@@ -2592,6 +2663,15 @@
       },
       [dispatch]
     );
+
+    const handlePanChange = useCallback((nextPan) => {
+      setPan((prev) => {
+        if (prev.x === nextPan.x && prev.y === nextPan.y) {
+          return prev;
+        }
+        return nextPan;
+      });
+    }, []);
 
     const handleDownload = () => {
       const payload = buildFlowExport(state);
@@ -2759,7 +2839,9 @@
           onDropNode: handleDropNode,
           onSelectNode: handleSelectNode,
           onMoveNode: handleMoveNode,
-          onOpenFlow: handleNavigateFlow
+          onOpenFlow: handleNavigateFlow,
+          pan,
+          onPanChange: handlePanChange
         }),
         h(ConfigPanel, {
           flows: state.flows,

--- a/dynaflow/ui/static/app.js
+++ b/dynaflow/ui/static/app.js
@@ -1458,6 +1458,7 @@
       top: { x: 0, y: -1 },
       bottom: { x: 0, y: 1 }
     };
+    const SIDE_ORDER = ['right', 'left', 'bottom', 'top'];
 
     const getAnchor = (rect, side) => {
       switch (side) {
@@ -1494,21 +1495,82 @@
         x: targetRect.left + targetRect.width / 2,
         y: targetRect.top + targetRect.height / 2
       };
-      const dx = targetCenter.x - sourceCenter.x;
-      const dy = targetCenter.y - sourceCenter.y;
 
-      if (Math.abs(dx) > Math.abs(dy)) {
+      const vectorToTarget = {
+        x: targetCenter.x - sourceCenter.x,
+        y: targetCenter.y - sourceCenter.y
+      };
+      const vectorToSource = {
+        x: sourceCenter.x - targetCenter.x,
+        y: sourceCenter.y - targetCenter.y
+      };
+
+      const scoreSides = (vector) =>
+        SIDE_ORDER.map((side) => ({
+          side,
+          score:
+            (vector.x || 0) * (SIDE_VECTORS[side].x || 0) +
+            (vector.y || 0) * (SIDE_VECTORS[side].y || 0)
+        })).sort((a, b) => b.score - a.score);
+
+      const sourceRanking = scoreSides(vectorToTarget);
+      const targetRanking = scoreSides(vectorToSource);
+
+      let best = null;
+
+      const limitSource = Math.min(3, sourceRanking.length);
+      const limitTarget = Math.min(3, targetRanking.length);
+
+      for (let i = 0; i < limitSource; i += 1) {
+        for (let j = 0; j < limitTarget; j += 1) {
+          const sourceSide = sourceRanking[i].side;
+          const targetSide = targetRanking[j].side;
+          const sourceAnchor = getAnchor(sourceRect, sourceSide);
+          const targetAnchor = getAnchor(targetRect, targetSide);
+          const vec = {
+            x: targetAnchor.x - sourceAnchor.x,
+            y: targetAnchor.y - sourceAnchor.y
+          };
+          const length = Math.hypot(vec.x, vec.y) || 1;
+          const sourceNormal = SIDE_VECTORS[sourceSide] || { x: 0, y: 0 };
+          const targetNormal = SIDE_VECTORS[targetSide] || { x: 0, y: 0 };
+          const sourceDot = vec.x * sourceNormal.x + vec.y * sourceNormal.y;
+          const targetDot = vec.x * targetNormal.x + vec.y * targetNormal.y;
+          const sourceAlignment = Math.max(0, Math.min(1, sourceDot / length));
+          const targetAlignment = Math.max(0, Math.min(1, -targetDot / length));
+
+          let penalty = 0;
+          if (sourceDot <= 0) {
+            penalty += Math.abs(sourceDot) * 600;
+          }
+          if (targetDot >= 0) {
+            penalty += Math.abs(targetDot) * 600;
+          }
+          penalty += (1 - sourceAlignment) * 160;
+          penalty += (1 - targetAlignment) * 160;
+
+          const cost = length + penalty;
+
+          if (!best || cost < best.cost) {
+            best = {
+              sourceSide,
+              targetSide,
+              cost
+            };
+          }
+        }
+      }
+
+      if (!best) {
         return {
-          sourceSide: dx >= 0 ? 'right' : 'left',
-          targetSide: dx >= 0 ? 'left' : 'right',
-          orientation: 'horizontal'
+          sourceSide: (sourceRanking[0] && sourceRanking[0].side) || 'right',
+          targetSide: (targetRanking[0] && targetRanking[0].side) || 'left'
         };
       }
 
       return {
-        sourceSide: dy >= 0 ? 'bottom' : 'top',
-        targetSide: dy >= 0 ? 'top' : 'bottom',
-        orientation: 'vertical'
+        sourceSide: best.sourceSide,
+        targetSide: best.targetSide
       };
     };
 
@@ -1547,14 +1609,15 @@
           return null;
         }
 
-        const { sourceSide, targetSide, orientation } = pickConnection(source, target);
+        const { sourceSide, targetSide } = pickConnection(source, target);
         const sourceAnchor = getAnchor(source, sourceSide);
         const targetAnchor = getAnchor(target, targetSide);
         const startPoint = sourceAnchor;
+        const arrowTip = offsetPoint(targetAnchor, targetSide, -0.75);
 
         let arrowVec = {
-          x: targetAnchor.x - startPoint.x,
-          y: targetAnchor.y - startPoint.y
+          x: arrowTip.x - startPoint.x,
+          y: arrowTip.y - startPoint.y
         };
         let arrowLength = Math.hypot(arrowVec.x, arrowVec.y);
         if (!arrowLength || !Number.isFinite(arrowLength)) {
@@ -1585,8 +1648,8 @@
         }
 
         const lineEnd = {
-          x: targetAnchor.x - directionVector.x * headLength,
-          y: targetAnchor.y - directionVector.y * headLength
+          x: arrowTip.x - directionVector.x * headLength,
+          y: arrowTip.y - directionVector.y * headLength
         };
 
         const pathDistance = Math.hypot(lineEnd.x - startPoint.x, lineEnd.y - startPoint.y);
@@ -1594,6 +1657,11 @@
         const baseCurve = pathDistance * 0.5;
         const curve = Math.min(220, Math.max(dynamicMin, baseCurve));
         const startVector = SIDE_VECTORS[sourceSide] || { x: 0, y: 0 };
+
+        const orientation =
+          Math.abs(lineEnd.x - startPoint.x) >= Math.abs(lineEnd.y - startPoint.y)
+            ? 'horizontal'
+            : 'vertical';
 
         let control1;
         let control2;
@@ -1625,8 +1693,8 @@
           `C ${control1.x} ${control1.y} ${control2.x} ${control2.y} ${lineEnd.x} ${lineEnd.y}`
         ].join(' ');
 
-        const arrowTipX = targetAnchor.x;
-        const arrowTipY = targetAnchor.y;
+        const arrowTipX = arrowTip.x;
+        const arrowTipY = arrowTip.y;
         const angle = Math.atan2(arrowTipY - lineEnd.y, arrowTipX - lineEnd.x);
         const leftX = arrowTipX - headLength * Math.cos(angle - Math.PI / 6);
         const leftY = arrowTipY - headLength * Math.sin(angle - Math.PI / 6);

--- a/dynaflow/ui/static/app.js
+++ b/dynaflow/ui/static/app.js
@@ -1452,6 +1452,76 @@
       };
     };
 
+    const SIDE_VECTORS = {
+      left: { x: -1, y: 0 },
+      right: { x: 1, y: 0 },
+      top: { x: 0, y: -1 },
+      bottom: { x: 0, y: 1 }
+    };
+
+    const getAnchor = (rect, side) => {
+      switch (side) {
+        case 'left':
+          return { x: rect.left, y: rect.top + rect.height / 2 };
+        case 'right':
+          return { x: rect.left + rect.width, y: rect.top + rect.height / 2 };
+        case 'top':
+          return { x: rect.left + rect.width / 2, y: rect.top };
+        case 'bottom':
+          return { x: rect.left + rect.width / 2, y: rect.top + rect.height };
+        default:
+          return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+      }
+    };
+
+    const offsetPoint = (point, side, distance) => {
+      if (!distance) {
+        return point;
+      }
+      const vector = SIDE_VECTORS[side] || { x: 0, y: 0 };
+      return {
+        x: point.x + vector.x * distance,
+        y: point.y + vector.y * distance
+      };
+    };
+
+    const pickConnection = (sourceRect, targetRect) => {
+      const sourceCenter = {
+        x: sourceRect.left + sourceRect.width / 2,
+        y: sourceRect.top + sourceRect.height / 2
+      };
+      const targetCenter = {
+        x: targetRect.left + targetRect.width / 2,
+        y: targetRect.top + targetRect.height / 2
+      };
+      const dx = targetCenter.x - sourceCenter.x;
+      const dy = targetCenter.y - sourceCenter.y;
+
+      if (Math.abs(dx) > Math.abs(dy)) {
+        return {
+          sourceSide: dx >= 0 ? 'right' : 'left',
+          targetSide: dx >= 0 ? 'left' : 'right',
+          orientation: 'horizontal'
+        };
+      }
+
+      return {
+        sourceSide: dy >= 0 ? 'bottom' : 'top',
+        targetSide: dy >= 0 ? 'top' : 'bottom',
+        orientation: 'vertical'
+      };
+    };
+
+    const cubicPoint = (p0, p1, p2, p3, t) => {
+      const mt = 1 - t;
+      return (
+        mt * mt * mt * p0 +
+        3 * mt * mt * t * p1 +
+        3 * mt * t * t * p2 +
+        t * t * t * p3
+      );
+    };
+
     return h(
       'svg',
       {
@@ -1477,37 +1547,102 @@
           return null;
         }
 
-        const sourceX = source.left + source.width;
-        const sourceY = source.top + source.height / 2;
-        const targetX = target.left;
-        const targetY = target.top + target.height / 2;
+        const { sourceSide, targetSide, orientation } = pickConnection(source, target);
+        const sourceAnchor = getAnchor(source, sourceSide);
+        const targetAnchor = getAnchor(target, targetSide);
+        const baseDx = targetAnchor.x - sourceAnchor.x;
+        const baseDy = targetAnchor.y - sourceAnchor.y;
+        const baseDistance = Math.hypot(baseDx, baseDy);
+        const startOffset = Math.min(
+          16,
+          Math.min(baseDistance * 0.5, Math.max(baseDistance * 0.3, 4))
+        );
+        const startPoint = offsetPoint(sourceAnchor, sourceSide, startOffset);
 
-        const direction = targetX >= sourceX ? 1 : -1;
-        const deltaX = Math.abs(targetX - sourceX);
-        const curve = Math.min(Math.max(deltaX * 0.5, 48), 240);
-        const control1X = sourceX + curve * direction;
-        const control2X = targetX - curve * direction;
-        const control1Y = sourceY;
-        const control2Y = targetY;
+        let arrowVec = {
+          x: targetAnchor.x - startPoint.x,
+          y: targetAnchor.y - startPoint.y
+        };
+        let arrowLength = Math.hypot(arrowVec.x, arrowVec.y);
+        if (!arrowLength || !Number.isFinite(arrowLength)) {
+          const fallback = SIDE_VECTORS[targetSide] || { x: 1, y: 0 };
+          arrowVec = { x: -fallback.x, y: -fallback.y };
+          arrowLength = Math.hypot(arrowVec.x, arrowVec.y);
+        }
+        const safeArrowLength = arrowLength || 1;
+        let directionVector = {
+          x: arrowVec.x / safeArrowLength,
+          y: arrowVec.y / safeArrowLength
+        };
+        if (!Number.isFinite(directionVector.x) || !Number.isFinite(directionVector.y)) {
+          const fallbackVector = SIDE_VECTORS[sourceSide] || { x: 1, y: 0 };
+          const fallbackLength = Math.hypot(fallbackVector.x, fallbackVector.y) || 1;
+          directionVector = {
+            x: fallbackVector.x / fallbackLength,
+            y: fallbackVector.y / fallbackLength
+          };
+        }
 
-        const dx = targetX - sourceX;
-        const dy = targetY - sourceY;
-        const angle = Math.atan2(dy, dx === 0 ? direction * 0.0001 : dx);
-        const arrowTipX = targetX - direction * 6;
-        const arrowTipY = targetY;
-        const lineEndX = arrowTipX - Math.cos(angle) * 8;
-        const lineEndY = arrowTipY - Math.sin(angle) * 8;
-        const path = `M ${sourceX} ${sourceY} C ${control1X} ${control1Y} ${control2X} ${control2Y} ${lineEndX} ${lineEndY}`;
+        let headLength = Math.min(12, Math.max(4, safeArrowLength * 0.25));
+        if (headLength > safeArrowLength - 2) {
+          headLength = Math.max(safeArrowLength * 0.5, safeArrowLength - 2);
+        }
+        if (headLength <= 0) {
+          headLength = safeArrowLength * 0.5;
+        }
 
-        const headLength = 10;
+        const lineEnd = {
+          x: targetAnchor.x - directionVector.x * headLength,
+          y: targetAnchor.y - directionVector.y * headLength
+        };
+
+        const pathDistance = Math.hypot(lineEnd.x - startPoint.x, lineEnd.y - startPoint.y);
+        const dynamicMin = pathDistance < 80 ? Math.max(pathDistance * 0.45, 8) : 40;
+        const baseCurve = pathDistance * 0.5;
+        const curve = Math.min(220, Math.max(dynamicMin, baseCurve));
+        const startVector = SIDE_VECTORS[sourceSide] || { x: 0, y: 0 };
+
+        let control1;
+        let control2;
+
+        if (orientation === 'horizontal') {
+          const deltaY = lineEnd.y - startPoint.y;
+          control1 = {
+            x: startPoint.x + startVector.x * curve,
+            y: startPoint.y + deltaY * 0.25
+          };
+          control2 = {
+            x: lineEnd.x - directionVector.x * curve,
+            y: lineEnd.y - deltaY * 0.25
+          };
+        } else {
+          const deltaX = lineEnd.x - startPoint.x;
+          control1 = {
+            x: startPoint.x + deltaX * 0.25,
+            y: startPoint.y + startVector.y * curve
+          };
+          control2 = {
+            x: lineEnd.x - deltaX * 0.25,
+            y: lineEnd.y - directionVector.y * curve
+          };
+        }
+
+        const path = [
+          `M ${startPoint.x} ${startPoint.y}`,
+          `C ${control1.x} ${control1.y} ${control2.x} ${control2.y} ${lineEnd.x} ${lineEnd.y}`
+        ].join(' ');
+
+        const arrowTipX = targetAnchor.x;
+        const arrowTipY = targetAnchor.y;
+        const angle = Math.atan2(arrowTipY - lineEnd.y, arrowTipX - lineEnd.x);
         const leftX = arrowTipX - headLength * Math.cos(angle - Math.PI / 6);
         const leftY = arrowTipY - headLength * Math.sin(angle - Math.PI / 6);
         const rightX = arrowTipX - headLength * Math.cos(angle + Math.PI / 6);
         const rightY = arrowTipY - headLength * Math.sin(angle + Math.PI / 6);
         const arrowHead = `M ${arrowTipX} ${arrowTipY} L ${leftX} ${leftY} L ${rightX} ${rightY} Z`;
 
-        const labelX = sourceX + (targetX - sourceX) * 0.5;
-        const labelY = sourceY + (targetY - sourceY) * 0.5 - 8;
+        const labelX = cubicPoint(startPoint.x, control1.x, control2.x, lineEnd.x, 0.5);
+        const labelY = cubicPoint(startPoint.y, control1.y, control2.y, lineEnd.y, 0.5) - 8;
 
         return h(
           'g',

--- a/dynaflow/ui/static/app.js
+++ b/dynaflow/ui/static/app.js
@@ -1550,14 +1550,7 @@
         const { sourceSide, targetSide, orientation } = pickConnection(source, target);
         const sourceAnchor = getAnchor(source, sourceSide);
         const targetAnchor = getAnchor(target, targetSide);
-        const baseDx = targetAnchor.x - sourceAnchor.x;
-        const baseDy = targetAnchor.y - sourceAnchor.y;
-        const baseDistance = Math.hypot(baseDx, baseDy);
-        const startOffset = Math.min(
-          16,
-          Math.min(baseDistance * 0.5, Math.max(baseDistance * 0.3, 4))
-        );
-        const startPoint = offsetPoint(sourceAnchor, sourceSide, startOffset);
+        const startPoint = sourceAnchor;
 
         let arrowVec = {
           x: targetAnchor.x - startPoint.x,

--- a/dynaflow/ui/static/minireact.js
+++ b/dynaflow/ui/static/minireact.js
@@ -1,6 +1,7 @@
 (function (global) {
   const TEXT_ELEMENT = "__text__";
   const Fragment = Symbol("Fragment");
+  const SVG_NS = "http://www.w3.org/2000/svg";
 
   class ComponentInstance {
     constructor(type, key) {
@@ -80,6 +81,31 @@
     return snapshot;
   }
 
+  function captureScrollSnapshot(container) {
+    if (!container) {
+      return [];
+    }
+    const result = [];
+    const elements = container.querySelectorAll("[data-mini-path]");
+    elements.forEach((element) => {
+      const path = element.getAttribute("data-mini-path");
+      if (!path) {
+        return;
+      }
+      const canScrollY = element.scrollHeight > element.clientHeight + 1;
+      const canScrollX = element.scrollWidth > element.clientWidth + 1;
+      if (!canScrollY && !canScrollX) {
+        return;
+      }
+      result.push({
+        path,
+        top: canScrollY ? element.scrollTop : null,
+        left: canScrollX ? element.scrollLeft : null
+      });
+    });
+    return result;
+  }
+
   function restoreFocusSnapshot(snapshot) {
     if (!snapshot || !rootContainer) {
       return;
@@ -112,6 +138,26 @@
         // ignore selection errors
       }
     }
+  }
+
+  function restoreScrollSnapshot(snapshot) {
+    if (!snapshot || !rootContainer) {
+      return;
+    }
+    snapshot.forEach((entry) => {
+      const target = rootContainer.querySelector(
+        `[data-mini-path="${escapeSelector(entry.path)}"]`
+      );
+      if (!target) {
+        return;
+      }
+      if (entry.top != null) {
+        target.scrollTop = entry.top;
+      }
+      if (entry.left != null) {
+        target.scrollLeft = entry.left;
+      }
+    });
   }
 
   function createElement(type, props, ...children) {
@@ -165,23 +211,27 @@
       return;
     }
     const focusSnapshot = captureFocusSnapshot(rootContainer);
+    const scrollSnapshot = captureScrollSnapshot(rootContainer);
     visitedInstances = new Set();
     queuedEffects = [];
     while (rootContainer.firstChild) {
       rootContainer.removeChild(rootContainer.firstChild);
     }
-    renderNode(rootElement, rootContainer, "root");
+    renderNode(rootElement, rootContainer, "root", null);
     cleanupUnusedInstances();
+    restoreScrollSnapshot(scrollSnapshot);
     restoreFocusSnapshot(focusSnapshot);
     runQueuedEffects();
   }
 
-  function renderNode(element, container, path) {
+  function renderNode(element, container, path, namespace) {
     if (element == null) {
       return;
     }
     if (Array.isArray(element)) {
-      element.forEach((child, index) => renderNode(child, container, path + "." + index));
+      element.forEach((child, index) =>
+        renderNode(child, container, path + "." + index, namespace)
+      );
       return;
     }
 
@@ -194,7 +244,9 @@
 
     if (type === Fragment) {
       const fragmentChildren = props.children || [];
-      fragmentChildren.forEach((child, index) => renderNode(child, container, path + "." + index));
+      fragmentChildren.forEach((child, index) =>
+        renderNode(child, container, path + "." + index, namespace)
+      );
       return;
     }
 
@@ -214,13 +266,17 @@
       instance.hookIndex = 0;
       instance.pendingEffects = [];
       const output = type(Object.assign({}, props));
-      renderNode(output, container, key);
+      renderNode(output, container, key, namespace);
       queuedEffects.push({ key, instance, effects: instance.pendingEffects.slice() });
       currentInstance = prevInstance;
       return;
     }
 
-    const dom = document.createElement(type);
+    const isSvg = namespace === SVG_NS || type === "svg";
+    const nextNamespace = type === "svg" ? SVG_NS : namespace;
+    const dom = isSvg
+      ? document.createElementNS(SVG_NS, type)
+      : document.createElement(type);
     visitedInstances.add(path);
     if (dom.dataset) {
       dom.dataset.miniPath = path;
@@ -229,7 +285,9 @@
     }
     applyProps(dom, {}, props || {});
     const children = props && props.children ? props.children : [];
-    children.forEach((child, index) => renderNode(child, dom, path + ":" + index));
+    children.forEach((child, index) =>
+      renderNode(child, dom, path + ":" + index, nextNamespace)
+    );
     if (
       type === "select" &&
       props &&

--- a/dynaflow/ui/static/minireact.js
+++ b/dynaflow/ui/static/minireact.js
@@ -20,6 +20,100 @@
   let visitedInstances = new Set();
   let queuedEffects = [];
 
+  const NON_TEXT_INPUT_TYPES = new Set([
+    "button",
+    "checkbox",
+    "color",
+    "file",
+    "hidden",
+    "image",
+    "radio",
+    "range",
+    "reset",
+    "submit"
+  ]);
+
+  function isTextLikeElement(element) {
+    if (!element) {
+      return false;
+    }
+    const tag = element.tagName;
+    if (tag === "TEXTAREA") {
+      return true;
+    }
+    if (tag === "INPUT") {
+      const type = (element.type || "").toLowerCase();
+      return !NON_TEXT_INPUT_TYPES.has(type);
+    }
+    return Boolean(element.isContentEditable);
+  }
+
+  function escapeSelector(value) {
+    if (global.CSS && typeof global.CSS.escape === "function") {
+      return global.CSS.escape(value);
+    }
+    return String(value).replace(/["\\]/g, "\\$&");
+  }
+
+  function captureFocusSnapshot(container) {
+    if (!container) {
+      return null;
+    }
+    const active = document.activeElement;
+    if (!active || !container.contains(active)) {
+      return null;
+    }
+    const path = active.dataset ? active.dataset.miniPath : null;
+    if (!path) {
+      return null;
+    }
+    const snapshot = { path };
+    if (isTextLikeElement(active)) {
+      try {
+        snapshot.selectionStart = active.selectionStart;
+        snapshot.selectionEnd = active.selectionEnd;
+      } catch (err) {
+        snapshot.selectionStart = null;
+        snapshot.selectionEnd = null;
+      }
+    }
+    return snapshot;
+  }
+
+  function restoreFocusSnapshot(snapshot) {
+    if (!snapshot || !rootContainer) {
+      return;
+    }
+    const target = rootContainer.querySelector(
+      `[data-mini-path="${escapeSelector(snapshot.path)}"]`
+    );
+    if (!target || typeof target.focus !== "function" || target.hasAttribute("disabled")) {
+      return;
+    }
+    try {
+      target.focus({ preventScroll: true });
+    } catch (err) {
+      target.focus();
+    }
+    if (
+      snapshot.selectionStart != null &&
+      typeof target.setSelectionRange === "function" &&
+      isTextLikeElement(target)
+    ) {
+      const value = target.value != null ? String(target.value) : "";
+      const length = value.length;
+      const start = Math.max(0, Math.min(snapshot.selectionStart, length));
+      const end = snapshot.selectionEnd != null
+        ? Math.max(0, Math.min(snapshot.selectionEnd, length))
+        : start;
+      try {
+        target.setSelectionRange(start, end);
+      } catch (err) {
+        // ignore selection errors
+      }
+    }
+  }
+
   function createElement(type, props, ...children) {
     const normalized = [];
     const rawChildren = (props && props.children) || [];
@@ -70,6 +164,7 @@
     if (!rootContainer || !rootElement) {
       return;
     }
+    const focusSnapshot = captureFocusSnapshot(rootContainer);
     visitedInstances = new Set();
     queuedEffects = [];
     while (rootContainer.firstChild) {
@@ -77,6 +172,7 @@
     }
     renderNode(rootElement, rootContainer, "root");
     cleanupUnusedInstances();
+    restoreFocusSnapshot(focusSnapshot);
     runQueuedEffects();
   }
 
@@ -126,9 +222,28 @@
 
     const dom = document.createElement(type);
     visitedInstances.add(path);
+    if (dom.dataset) {
+      dom.dataset.miniPath = path;
+    } else {
+      dom.setAttribute("data-mini-path", path);
+    }
     applyProps(dom, {}, props || {});
     const children = props && props.children ? props.children : [];
     children.forEach((child, index) => renderNode(child, dom, path + ":" + index));
+    if (
+      type === "select" &&
+      props &&
+      Object.prototype.hasOwnProperty.call(props, "value")
+    ) {
+      dom.value = props.value == null ? "" : props.value;
+    }
+    if (
+      (type === "input" || type === "textarea") &&
+      props &&
+      Object.prototype.hasOwnProperty.call(props, "value")
+    ) {
+      dom.value = props.value == null ? "" : props.value;
+    }
     container.appendChild(dom);
   }
 
@@ -166,6 +281,16 @@
     if (name.startsWith("on") && typeof value === "function") {
       const eventName = name.slice(2).toLowerCase();
       dom.addEventListener(eventName, value);
+      return;
+    }
+    if (name === "selected" && "selected" in dom) {
+      const isSelected = Boolean(value);
+      dom.selected = isSelected;
+      if (!isSelected) {
+        dom.removeAttribute("selected");
+      } else {
+        dom.setAttribute("selected", "");
+      }
       return;
     }
     if (name === "value" && "value" in dom) {

--- a/dynaflow/ui/static/minireact.js
+++ b/dynaflow/ui/static/minireact.js
@@ -168,6 +168,19 @@
       dom.addEventListener(eventName, value);
       return;
     }
+    if (name === "value" && "value" in dom) {
+      if (value === false || value === null || value === undefined) {
+        dom.value = "";
+        dom.removeAttribute("value");
+      } else {
+        dom.value = value;
+      }
+      return;
+    }
+    if (name === "checked" && "checked" in dom) {
+      dom.checked = Boolean(value);
+      return;
+    }
     if (value === false || value === null || value === undefined) {
       dom.removeAttribute(name);
       return;

--- a/dynaflow/ui/static/styles.css
+++ b/dynaflow/ui/static/styles.css
@@ -367,6 +367,13 @@ body {
   position: relative;
   width: 100%;
   height: 100%;
+  cursor: grab;
+  transition: transform 0.12s ease-out;
+}
+
+.canvas-inner.is-panning {
+  cursor: grabbing;
+  transition: none;
 }
 
 .node-card {
@@ -383,6 +390,40 @@ body {
   -moz-user-select: none;
   -ms-user-select: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.node-marker {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.node-marker-start {
+  left: -12px;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.node-marker-end {
+  right: -12px;
+  top: 50%;
+  transform: translate(50%, -50%);
+  background: transparent;
+  border: 3px solid var(--danger);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.2);
+}
+
+.node-marker-end::after {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  background: var(--danger);
 }
 
 .node-card:active {

--- a/dynaflow/ui/static/styles.css
+++ b/dynaflow/ui/static/styles.css
@@ -361,6 +361,7 @@ body {
   background-size: 80px 80px;
   mask-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.8), transparent 70%);
   pointer-events: none;
+  z-index: 0;
 }
 
 .canvas-inner {
@@ -369,6 +370,7 @@ body {
   height: 100%;
   cursor: grab;
   transition: transform 0.12s ease-out;
+  z-index: 2;
 }
 
 .canvas-inner.is-panning {
@@ -390,6 +392,7 @@ body {
   -moz-user-select: none;
   -ms-user-select: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  z-index: 3;
 }
 
 .node-marker {
@@ -531,7 +534,7 @@ body {
 
 .link-canvas path {
   stroke: var(--accent);
-  stroke-width: 2;
+  stroke-width: 3;
   fill: none;
   opacity: 0.8;
 }
@@ -893,8 +896,26 @@ body {
   background: rgba(30, 41, 59, 0.7);
   margin-bottom: 12px;
   display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.branch-card-header {
+  display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
+}
+
+.branch-name {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.branch-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .branch-card button {
@@ -908,6 +929,28 @@ body {
 
 .branch-card button:hover {
   background: rgba(56, 189, 248, 0.3);
+}
+
+.branch-card .form-field {
+  margin-bottom: 0;
+}
+
+.form-field.condensed label {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.form-field.condensed select {
+  width: 100%;
+}
+
+.branch-hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: rgba(148, 163, 184, 0.08);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
 }
 
 @media (max-width: 1280px) {


### PR DESCRIPTION
## Summary
- keep the "Next state" selector in sync with node transitions so selections persist
- wire the canvas ref correctly, render connection lines and add mouse panning for large flows
- decorate start/end nodes with UML-like markers and update styles for the new interactions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d351272a3083299d5e1718331051d5